### PR TITLE
Functions with multi-expression bodies

### DIFF
--- a/src/__tests__/__snapshots__/parser-tests.js.snap
+++ b/src/__tests__/__snapshots__/parser-tests.js.snap
@@ -3,10 +3,12 @@ Array [
   Object {
     "clauses": Array [
       Object {
-        "body": Object {
-          "type": "Numeral",
-          "value": 1,
-        },
+        "body": Array [
+          Object {
+            "type": "Numeral",
+            "value": 1,
+          },
+        ],
         "pattern": Array [
           Object {
             "head": Object {
@@ -32,10 +34,12 @@ Array [
   Object {
     "clauses": Array [
       Object {
-        "body": Object {
-          "type": "Numeral",
-          "value": 1,
-        },
+        "body": Array [
+          Object {
+            "type": "Numeral",
+            "value": 1,
+          },
+        ],
         "pattern": Array [
           Object {
             "type": "Bool",
@@ -57,10 +61,12 @@ Array [
     "value": Object {
       "clauses": Array [
         Object {
-          "body": Object {
-            "type": "Numeral",
-            "value": 1,
-          },
+          "body": Array [
+            Object {
+              "type": "Numeral",
+              "value": 1,
+            },
+          ],
           "pattern": Array [
             Object {
               "type": "Numeral",
@@ -69,10 +75,12 @@ Array [
           ],
         },
         Object {
-          "body": Object {
-            "type": "Numeral",
-            "value": 1,
-          },
+          "body": Array [
+            Object {
+              "type": "Numeral",
+              "value": 1,
+            },
+          ],
           "pattern": Array [
             Object {
               "type": "Numeral",
@@ -81,67 +89,69 @@ Array [
           ],
         },
         Object {
-          "body": Object {
-            "args": Array [
-              Object {
-                "args": Array [
-                  Object {
-                    "args": Array [
-                      Object {
-                        "name": "x",
+          "body": Array [
+            Object {
+              "args": Array [
+                Object {
+                  "args": Array [
+                    Object {
+                      "args": Array [
+                        Object {
+                          "name": "x",
+                          "type": "Name",
+                        },
+                        Object {
+                          "type": "Numeral",
+                          "value": 1,
+                        },
+                      ],
+                      "fn": Object {
+                        "name": "-",
                         "type": "Name",
                       },
-                      Object {
-                        "type": "Numeral",
-                        "value": 1,
-                      },
-                    ],
-                    "fn": Object {
-                      "name": "-",
-                      "type": "Name",
+                      "type": "Call",
                     },
-                    "type": "Call",
+                  ],
+                  "fn": Object {
+                    "name": "fib",
+                    "type": "Name",
                   },
-                ],
-                "fn": Object {
-                  "name": "fib",
-                  "type": "Name",
+                  "type": "Call",
                 },
-                "type": "Call",
-              },
-              Object {
-                "args": Array [
-                  Object {
-                    "args": Array [
-                      Object {
-                        "name": "x",
+                Object {
+                  "args": Array [
+                    Object {
+                      "args": Array [
+                        Object {
+                          "name": "x",
+                          "type": "Name",
+                        },
+                        Object {
+                          "type": "Numeral",
+                          "value": 2,
+                        },
+                      ],
+                      "fn": Object {
+                        "name": "-",
                         "type": "Name",
                       },
-                      Object {
-                        "type": "Numeral",
-                        "value": 2,
-                      },
-                    ],
-                    "fn": Object {
-                      "name": "-",
-                      "type": "Name",
+                      "type": "Call",
                     },
-                    "type": "Call",
+                  ],
+                  "fn": Object {
+                    "name": "fib",
+                    "type": "Name",
                   },
-                ],
-                "fn": Object {
-                  "name": "fib",
-                  "type": "Name",
+                  "type": "Call",
                 },
-                "type": "Call",
+              ],
+              "fn": Object {
+                "name": "+",
+                "type": "Name",
               },
-            ],
-            "fn": Object {
-              "name": "+",
-              "type": "Name",
+              "type": "Call",
             },
-            "type": "Call",
-          },
+          ],
           "pattern": Array [
             Object {
               "name": "x",
@@ -271,10 +281,12 @@ Array [
     "value": Object {
       "clauses": Array [
         Object {
-          "body": Object {
-            "name": "n",
-            "type": "Name",
-          },
+          "body": Array [
+            Object {
+              "name": "n",
+              "type": "Name",
+            },
+          ],
           "pattern": Array [
             Object {
               "name": "n",
@@ -287,49 +299,51 @@ Array [
           ],
         },
         Object {
-          "body": Object {
-            "args": Array [
-              Object {
-                "args": Array [
-                  Object {
-                    "name": "n",
+          "body": Array [
+            Object {
+              "args": Array [
+                Object {
+                  "args": Array [
+                    Object {
+                      "name": "n",
+                      "type": "Name",
+                    },
+                    Object {
+                      "name": "x",
+                      "type": "Name",
+                    },
+                  ],
+                  "fn": Object {
+                    "name": "*",
                     "type": "Name",
                   },
-                  Object {
-                    "name": "x",
-                    "type": "Name",
-                  },
-                ],
-                "fn": Object {
-                  "name": "*",
-                  "type": "Name",
+                  "type": "Call",
                 },
-                "type": "Call",
-              },
-              Object {
-                "args": Array [
-                  Object {
-                    "name": "x",
+                Object {
+                  "args": Array [
+                    Object {
+                      "name": "x",
+                      "type": "Name",
+                    },
+                    Object {
+                      "type": "Numeral",
+                      "value": 1,
+                    },
+                  ],
+                  "fn": Object {
+                    "name": "-",
                     "type": "Name",
                   },
-                  Object {
-                    "type": "Numeral",
-                    "value": 1,
-                  },
-                ],
-                "fn": Object {
-                  "name": "-",
-                  "type": "Name",
+                  "type": "Call",
                 },
-                "type": "Call",
+              ],
+              "fn": Object {
+                "name": "factorial",
+                "type": "Name",
               },
-            ],
-            "fn": Object {
-              "name": "factorial",
-              "type": "Name",
+              "type": "Call",
             },
-            "type": "Call",
-          },
+          ],
           "pattern": Array [
             Object {
               "name": "n",
@@ -351,23 +365,25 @@ Array [
     "value": Object {
       "clauses": Array [
         Object {
-          "body": Object {
-            "args": Array [
-              Object {
-                "type": "Numeral",
-                "value": 1,
-              },
-              Object {
-                "name": "n",
+          "body": Array [
+            Object {
+              "args": Array [
+                Object {
+                  "type": "Numeral",
+                  "value": 1,
+                },
+                Object {
+                  "name": "n",
+                  "type": "Name",
+                },
+              ],
+              "fn": Object {
+                "name": "factorial",
                 "type": "Name",
               },
-            ],
-            "fn": Object {
-              "name": "factorial",
-              "type": "Name",
+              "type": "Call",
             },
-            "type": "Call",
-          },
+          ],
           "pattern": Array [
             Object {
               "name": "n",

--- a/src/__tests__/__snapshots__/type-checker-tests.js.snap
+++ b/src/__tests__/__snapshots__/type-checker-tests.js.snap
@@ -118,6 +118,24 @@ Array [
 ]
 `;
 
+exports[`test 
+1 => 2
+x => {
+  y = 3
+  f = a => 2
+  (f y)
+} 1`] = `
+Array [
+  "Number -> Number",
+]
+`;
+
+exports[`test 
+x => {
+  x = 3
+  x
+} 1`] = `"x has already been defined"`;
+
 exports[`test ((() => \`look ma no args\`)) 1`] = `
 Array [
   "String",

--- a/src/__tests__/lang-tests.js
+++ b/src/__tests__/lang-tests.js
@@ -241,3 +241,39 @@ f = (a, b) =>
 ((f 5 6))
 
 `, 18)
+
+// Functions with multi-expression bodies
+testResult(`
+f =
+  1 => 2
+  x => {
+    y = 3
+    (print y)
+    (+ y x)
+  }
+(f 2)
+`, 5)
+
+// Inner expressions are applied in series, so they can use defs
+// from earlier in the same block
+testResult(`
+f = a => {
+  g = b => 10
+  c = (g a)
+  (+ a c)
+}
+(f 2)
+`, 12)
+
+// Inner defs have nested scopes
+testResult(`
+a = 1
+f = a => {
+  g = b => {
+    a = 3
+    (+ b a)
+  }
+  [a, (g a)]
+}
+[[a], (f 2)]
+`, [[1], [2, 5]])

--- a/src/__tests__/type-checker-tests.js
+++ b/src/__tests__/type-checker-tests.js
@@ -242,3 +242,19 @@ testTypeCheck(`
 
 // FIXME #6 - extra parens needed to immediately invoke a no-arg function
 testTypeCheck('((() => `look ma no args`))')
+
+// Functions with multi expression bodies
+testTypeCheck(`
+1 => 2
+x => {
+  y = 3
+  f = a => 2
+  (f y)
+}`)
+
+// defs can't use already-bound names
+testFails(`
+x => {
+  x = 3
+  x
+}`)

--- a/src/peach.pegjs
+++ b/src/peach.pegjs
@@ -46,9 +46,13 @@ clause_list = head:clause tail:(__ c:clause { return c })* {
   return [head, ...tail];
 }
 
-clause = pattern:pattern __ "=>" __ body:expression {
-  return { pattern, body };
+clause = pattern:pattern __ "=>" __ body:clause_body {
+  return Object.assign({ pattern }, body );
 }
+
+clause_body
+  = single_expr:expression { return { body: [single_expr] } }
+  / lb body:expression_list rb { return { body } }
 
 pattern
   = lp rp { return [] }
@@ -83,6 +87,7 @@ if = "if" _ lp condition:expression rp __ ifBranch:expression __ "else" __ elseB
     elseBranch
   }
 }
+
 
 name = value:name_value {
   return {
@@ -172,6 +177,10 @@ rp = _ ")" { return ")" }
 
 ls = "[" _ { return "[" }
 rs = _ "]" { return "]" }
+
+// FIXME for some reason { and } cause pegjs syntax errors in return blocks
+lb = "{" _ { return "lb" }
+rb = _ "}" { return "rb" }
 
 // mandatory whitespace
 __ = ignored+

--- a/src/type-checker.js
+++ b/src/type-checker.js
@@ -27,11 +27,14 @@ function getTypeEnv (valueEnv) {
 
 module.exports.getTypeEnv = getTypeEnv
 
-// Visit each of `nodes` in order, returning the result
-// and environment of the last node.
-// returns [typedNode, env]
 function visitAll (nodes, env, nonGeneric) {
   return nodes.map(node => visit(node, env, nonGeneric))
+}
+
+function visitSerial (nodes, env, nonGeneric) {
+  return nodes.reduce(([, nextEnv], nextNode) =>
+    visit(nextNode, nextEnv, nonGeneric)
+  , [null, env])
 }
 
 function visit (node, env, nonGeneric) {
@@ -170,8 +173,8 @@ const visitors = {
         return typeOf(typedArgNode)
       })
 
-      const [bodyNode] = visit(clauseNode.body, env, nonGeneric)
-      const returnType = prune(typeOf(bodyNode))
+      const [lastBodyNode] = visitSerial(clauseNode.body, env, nonGeneric)
+      const returnType = prune(typeOf(lastBodyNode))
 
       const clauseType = makeFunctionType(patternTypes, returnType)
       return typed(clauseNode, clauseType)
@@ -205,11 +208,6 @@ function typeOf (node) {
 // return an array of types for the given array of typed nodes
 function typesOf (typedNodes) {
   return typedNodes.map(node => node.exprType)
-}
-
-// return the type of a function call
-function callFunction (fn, args) {
-
 }
 
 //

--- a/src/util.js
+++ b/src/util.js
@@ -10,7 +10,7 @@ function create (proto, properties) {
 }
 
 function restAndLast (arr) {
-  const last = arr.slice(-1)
+  const [last] = arr.slice(-1)
   const rest = arr.slice(0, -1)
   return [rest, last]
 }


### PR DESCRIPTION
Allow functions to have several expressions as their body. The main use case is to allow definitions in a function body, like a Lisp `let` expression. 

The Peach version, however, allows _any_ expression type. That includes `print`, which is the only side effect in the language at the moment. I decided that the flexibility and debugging friendliness of allowing `print` _anywhere_ is more important than purity, at least until I decide how Peach will deal with side effects in general.