### PR TITLE
Start to add static types for the language engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ jspm_packages
 
 # Misc
 .DS_Store
+.vscode

--- a/src/__tests__/__snapshots__/parser-tests.ts.snap
+++ b/src/__tests__/__snapshots__/parser-tests.ts.snap
@@ -1,66 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`([true|tail] => 1) 1`] = `
-Array [
-  Object {
-    "clauses": Array [
-      Object {
-        "body": Array [
-          Object {
-            "type": "Numeral",
-            "value": 1,
-          },
-        ],
-        "pattern": Array [
-          Object {
-            "head": Object {
-              "type": "Bool",
-              "value": true,
-            },
-            "tail": Object {
-              "name": "tail",
-              "type": "Name",
-            },
-            "type": "DestructuredArray",
-          },
-        ],
-      },
-    ],
-    "type": "Fn",
-  },
-]
-`;
-
-exports[`(true => 1) 1`] = `
-Array [
-  Object {
-    "clauses": Array [
-      Object {
-        "body": Array [
-          Object {
-            "type": "Numeral",
-            "value": 1,
-          },
-        ],
-        "pattern": Array [
-          Object {
-            "type": "Bool",
-            "value": true,
-          },
-        ],
-      },
-    ],
-    "type": "Fn",
-  },
-]
-`;
-
-exports[`fibonacci.peach 1`] = `
-Array [
-  Object {
-    "name": "fib",
-    "type": "Def",
-    "value": Object {
+Object {
+  "expressions": Array [
+    Object {
       "clauses": Array [
         Object {
           "body": Array [
@@ -70,345 +13,417 @@ Array [
             },
           ],
           "pattern": Array [
+            Object {
+              "head": Object {
+                "type": "Bool",
+                "value": true,
+              },
+              "tail": Object {
+                "name": "tail",
+                "type": "Name",
+              },
+              "type": "DestructuredArray",
+            },
+          ],
+        },
+      ],
+      "type": "Fn",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
+exports[`(true => 1) 1`] = `
+Object {
+  "expressions": Array [
+    Object {
+      "clauses": Array [
+        Object {
+          "body": Array [
+            Object {
+              "type": "Numeral",
+              "value": 1,
+            },
+          ],
+          "pattern": Array [
+            Object {
+              "type": "Bool",
+              "value": true,
+            },
+          ],
+        },
+      ],
+      "type": "Fn",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
+exports[`fibonacci.peach 1`] = `
+Object {
+  "expressions": Array [
+    Object {
+      "name": "fib",
+      "type": "Def",
+      "value": Object {
+        "clauses": Array [
+          Object {
+            "body": Array [
+              Object {
+                "type": "Numeral",
+                "value": 1,
+              },
+            ],
+            "pattern": Array [
+              Object {
+                "type": "Numeral",
+                "value": 0,
+              },
+            ],
+          },
+          Object {
+            "body": Array [
+              Object {
+                "type": "Numeral",
+                "value": 1,
+              },
+            ],
+            "pattern": Array [
+              Object {
+                "type": "Numeral",
+                "value": 1,
+              },
+            ],
+          },
+          Object {
+            "body": Array [
+              Object {
+                "args": Array [
+                  Object {
+                    "args": Array [
+                      Object {
+                        "args": Array [
+                          Object {
+                            "name": "x",
+                            "type": "Name",
+                          },
+                          Object {
+                            "type": "Numeral",
+                            "value": 1,
+                          },
+                        ],
+                        "fn": Object {
+                          "name": "-",
+                          "type": "Name",
+                        },
+                        "type": "Call",
+                      },
+                    ],
+                    "fn": Object {
+                      "name": "fib",
+                      "type": "Name",
+                    },
+                    "type": "Call",
+                  },
+                  Object {
+                    "args": Array [
+                      Object {
+                        "args": Array [
+                          Object {
+                            "name": "x",
+                            "type": "Name",
+                          },
+                          Object {
+                            "type": "Numeral",
+                            "value": 2,
+                          },
+                        ],
+                        "fn": Object {
+                          "name": "-",
+                          "type": "Name",
+                        },
+                        "type": "Call",
+                      },
+                    ],
+                    "fn": Object {
+                      "name": "fib",
+                      "type": "Name",
+                    },
+                    "type": "Call",
+                  },
+                ],
+                "fn": Object {
+                  "name": "+",
+                  "type": "Name",
+                },
+                "type": "Call",
+              },
+            ],
+            "pattern": Array [
+              Object {
+                "name": "x",
+                "type": "Name",
+              },
+            ],
+          },
+        ],
+        "type": "Fn",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "name": "fib",
+          "type": "Name",
+        },
+        Object {
+          "type": "Array",
+          "values": Array [
             Object {
               "type": "Numeral",
               "value": 0,
             },
-          ],
-        },
-        Object {
-          "body": Array [
             Object {
               "type": "Numeral",
               "value": 1,
             },
-          ],
-          "pattern": Array [
             Object {
               "type": "Numeral",
-              "value": 1,
+              "value": 2,
             },
-          ],
-        },
-        Object {
-          "body": Array [
             Object {
-              "args": Array [
-                Object {
-                  "args": Array [
-                    Object {
-                      "args": Array [
-                        Object {
-                          "name": "x",
-                          "type": "Name",
-                        },
-                        Object {
-                          "type": "Numeral",
-                          "value": 1,
-                        },
-                      ],
-                      "fn": Object {
-                        "name": "-",
-                        "type": "Name",
-                      },
-                      "type": "Call",
-                    },
-                  ],
-                  "fn": Object {
-                    "name": "fib",
-                    "type": "Name",
-                  },
-                  "type": "Call",
-                },
-                Object {
-                  "args": Array [
-                    Object {
-                      "args": Array [
-                        Object {
-                          "name": "x",
-                          "type": "Name",
-                        },
-                        Object {
-                          "type": "Numeral",
-                          "value": 2,
-                        },
-                      ],
-                      "fn": Object {
-                        "name": "-",
-                        "type": "Name",
-                      },
-                      "type": "Call",
-                    },
-                  ],
-                  "fn": Object {
-                    "name": "fib",
-                    "type": "Name",
-                  },
-                  "type": "Call",
-                },
-              ],
-              "fn": Object {
-                "name": "+",
-                "type": "Name",
-              },
-              "type": "Call",
+              "type": "Numeral",
+              "value": 3,
             },
-          ],
-          "pattern": Array [
             Object {
-              "name": "x",
-              "type": "Name",
+              "type": "Numeral",
+              "value": 4,
+            },
+            Object {
+              "type": "Numeral",
+              "value": 5,
+            },
+            Object {
+              "type": "Numeral",
+              "value": 6,
+            },
+            Object {
+              "type": "Numeral",
+              "value": 7,
+            },
+            Object {
+              "type": "Numeral",
+              "value": 8,
+            },
+            Object {
+              "type": "Numeral",
+              "value": 9,
+            },
+            Object {
+              "type": "Numeral",
+              "value": 10,
             },
           ],
         },
       ],
-      "type": "Fn",
-    },
-  },
-  Object {
-    "args": Array [
-      Object {
-        "name": "fib",
+      "fn": Object {
+        "name": "map",
         "type": "Name",
       },
-      Object {
-        "type": "Array",
-        "values": Array [
-          Object {
-            "type": "Numeral",
-            "value": 0,
-          },
-          Object {
-            "type": "Numeral",
-            "value": 1,
-          },
-          Object {
-            "type": "Numeral",
-            "value": 2,
-          },
-          Object {
-            "type": "Numeral",
-            "value": 3,
-          },
-          Object {
-            "type": "Numeral",
-            "value": 4,
-          },
-          Object {
-            "type": "Numeral",
-            "value": 5,
-          },
-          Object {
-            "type": "Numeral",
-            "value": 6,
-          },
-          Object {
-            "type": "Numeral",
-            "value": 7,
-          },
-          Object {
-            "type": "Numeral",
-            "value": 8,
-          },
-          Object {
-            "type": "Numeral",
-            "value": 9,
-          },
-          Object {
-            "type": "Numeral",
-            "value": 10,
-          },
-        ],
-      },
-    ],
-    "fn": Object {
-      "name": "map",
-      "type": "Name",
+      "type": "Call",
     },
-    "type": "Call",
-  },
-]
+  ],
+  "type": "Program",
+}
 `;
 
 exports[`str.peach 1`] = `
-Array [
-  Object {
-    "type": "Array",
-    "values": Array [
-      Object {
-        "type": "Str",
-        "value": "str.peach before escape\\\\\`and after!",
-      },
-      Object {
-        "type": "Str",
-        "value": "hey 🌟",
-      },
-      Object {
-        "type": "Str",
-        "value": "multi
+Object {
+  "expressions": Array [
+    Object {
+      "type": "Array",
+      "values": Array [
+        Object {
+          "type": "Str",
+          "value": "str.peach before escape\\\\\`and after!",
+        },
+        Object {
+          "type": "Str",
+          "value": "hey 🌟",
+        },
+        Object {
+          "type": "Str",
+          "value": "multi
       line
   string",
-      },
-      Object {
-        "type": "Str",
-        "value": "such\\\\\\\\\\\\\\\\\\\\\`escape",
-      },
-      Object {
-        "type": "Str",
-        "value": "with	tab",
-      },
-      Object {
-        "type": "Str",
-        "value": "new
+        },
+        Object {
+          "type": "Str",
+          "value": "such\\\\\\\\\\\\\\\\\\\\\`escape",
+        },
+        Object {
+          "type": "Str",
+          "value": "with	tab",
+        },
+        Object {
+          "type": "Str",
+          "value": "new
 line",
-      },
-      Object {
-        "type": "Str",
-        "value": "back\\\\slash",
-      },
-      Object {
-        "type": "Str",
-        "value": "back\\\\\\\\to\\\\back",
-      },
-    ],
-  },
-]
+        },
+        Object {
+          "type": "Str",
+          "value": "back\\\\slash",
+        },
+        Object {
+          "type": "Str",
+          "value": "back\\\\\\\\to\\\\back",
+        },
+      ],
+    },
+  ],
+  "type": "Program",
+}
 `;
 
 exports[`tail-recursion.peach 1`] = `
-Array [
-  Object {
-    "name": "factorial",
-    "type": "Def",
-    "value": Object {
-      "clauses": Array [
-        Object {
-          "body": Array [
-            Object {
-              "name": "n",
-              "type": "Name",
-            },
-          ],
-          "pattern": Array [
-            Object {
-              "name": "n",
-              "type": "Name",
-            },
-            Object {
-              "type": "Numeral",
-              "value": 1,
-            },
-          ],
-        },
-        Object {
-          "body": Array [
-            Object {
-              "args": Array [
-                Object {
-                  "args": Array [
-                    Object {
-                      "name": "n",
-                      "type": "Name",
-                    },
-                    Object {
-                      "name": "x",
-                      "type": "Name",
-                    },
-                  ],
-                  "fn": Object {
-                    "name": "*",
-                    "type": "Name",
-                  },
-                  "type": "Call",
-                },
-                Object {
-                  "args": Array [
-                    Object {
-                      "name": "x",
-                      "type": "Name",
-                    },
-                    Object {
-                      "type": "Numeral",
-                      "value": 1,
-                    },
-                  ],
-                  "fn": Object {
-                    "name": "-",
-                    "type": "Name",
-                  },
-                  "type": "Call",
-                },
-              ],
-              "fn": Object {
-                "name": "factorial",
+Object {
+  "expressions": Array [
+    Object {
+      "name": "factorial",
+      "type": "Def",
+      "value": Object {
+        "clauses": Array [
+          Object {
+            "body": Array [
+              Object {
+                "name": "n",
                 "type": "Name",
               },
-              "type": "Call",
-            },
-          ],
-          "pattern": Array [
-            Object {
-              "name": "n",
-              "type": "Name",
-            },
-            Object {
-              "name": "x",
-              "type": "Name",
-            },
-          ],
-        },
-      ],
-      "type": "Fn",
-    },
-  },
-  Object {
-    "name": "f",
-    "type": "Def",
-    "value": Object {
-      "clauses": Array [
-        Object {
-          "body": Array [
-            Object {
-              "args": Array [
-                Object {
-                  "type": "Numeral",
-                  "value": 1,
-                },
-                Object {
-                  "name": "n",
+            ],
+            "pattern": Array [
+              Object {
+                "name": "n",
+                "type": "Name",
+              },
+              Object {
+                "type": "Numeral",
+                "value": 1,
+              },
+            ],
+          },
+          Object {
+            "body": Array [
+              Object {
+                "args": Array [
+                  Object {
+                    "args": Array [
+                      Object {
+                        "name": "n",
+                        "type": "Name",
+                      },
+                      Object {
+                        "name": "x",
+                        "type": "Name",
+                      },
+                    ],
+                    "fn": Object {
+                      "name": "*",
+                      "type": "Name",
+                    },
+                    "type": "Call",
+                  },
+                  Object {
+                    "args": Array [
+                      Object {
+                        "name": "x",
+                        "type": "Name",
+                      },
+                      Object {
+                        "type": "Numeral",
+                        "value": 1,
+                      },
+                    ],
+                    "fn": Object {
+                      "name": "-",
+                      "type": "Name",
+                    },
+                    "type": "Call",
+                  },
+                ],
+                "fn": Object {
+                  "name": "factorial",
                   "type": "Name",
                 },
-              ],
-              "fn": Object {
-                "name": "factorial",
+                "type": "Call",
+              },
+            ],
+            "pattern": Array [
+              Object {
+                "name": "n",
                 "type": "Name",
               },
-              "type": "Call",
-            },
-          ],
-          "pattern": Array [
-            Object {
-              "name": "n",
-              "type": "Name",
-            },
-          ],
+              Object {
+                "name": "x",
+                "type": "Name",
+              },
+            ],
+          },
+        ],
+        "type": "Fn",
+      },
+    },
+    Object {
+      "name": "f",
+      "type": "Def",
+      "value": Object {
+        "clauses": Array [
+          Object {
+            "body": Array [
+              Object {
+                "args": Array [
+                  Object {
+                    "type": "Numeral",
+                    "value": 1,
+                  },
+                  Object {
+                    "name": "n",
+                    "type": "Name",
+                  },
+                ],
+                "fn": Object {
+                  "name": "factorial",
+                  "type": "Name",
+                },
+                "type": "Call",
+              },
+            ],
+            "pattern": Array [
+              Object {
+                "name": "n",
+                "type": "Name",
+              },
+            ],
+          },
+        ],
+        "type": "Fn",
+      },
+    },
+    Object {
+      "args": Array [
+        Object {
+          "type": "Numeral",
+          "value": 32768,
         },
       ],
-      "type": "Fn",
-    },
-  },
-  Object {
-    "args": Array [
-      Object {
-        "type": "Numeral",
-        "value": 32768,
+      "fn": Object {
+        "name": "f",
+        "type": "Name",
       },
-    ],
-    "fn": Object {
-      "name": "f",
-      "type": "Name",
+      "type": "Call",
     },
-    "type": "Call",
-  },
-]
+  ],
+  "type": "Program",
+}
 `;

--- a/src/__tests__/__snapshots__/type-checker-tests.ts.snap
+++ b/src/__tests__/__snapshots__/type-checker-tests.ts.snap
@@ -11,17 +11,7 @@ exports[`
   (f 3)
   (f 3 4)
   ((f 3) 4)
- 1`] = `
-Array [
-  "Number -> Number -> Array<Number>",
-  "Number -> Array<Number>",
-  "Array<Number>",
-  "Array<Number>",
-  "Number -> Array<Number>",
-  "Array<Number>",
-  "Array<Number>",
-]
-`;
+ 1`] = `"Array<Number>"`;
 
 exports[`
   fibc =
@@ -33,34 +23,18 @@ exports[`
 exports[`
   g = f => 5
   (g g)
- 1`] = `
-Array [
-  "M -> Number",
-  "Number",
-]
-`;
+ 1`] = `"Number"`;
 
 exports[`
   id = x => x
   ((pair (id 3)) (id true))
- 1`] = `
-Array [
-  "K -> K",
-  "L",
-]
-`;
+ 1`] = `"G"`;
 
 exports[`
   id = x => x
   (id 3)
   (id \`hello\`)
- 1`] = `
-Array [
-  "J -> J",
-  "Number",
-  "String",
-]
-`;
+ 1`] = `"String"`;
 
 exports[`
   list = (a, b, c) => [a b c]
@@ -74,51 +48,26 @@ exports[`
   (list 1 2 3)
   ((list 1) 2 3)
   (list true false true)
- 1`] = `
-Array [
-  "R -> R -> R -> Array<R>",
-  "Number -> Number -> Array<Number>",
-  "Number -> Array<Number>",
-  "Array<Number>",
-  "Array<Number>",
-  "Array<Boolean>",
-]
-`;
+ 1`] = `"Array<Boolean>"`;
 
 exports[`
   x = \`arf\`
   x
- 1`] = `
-Array [
-  "String",
-  "String",
-]
-`;
+ 1`] = `"String"`;
 
 exports[`
   x = 1
   y = true
   x
   y
- 1`] = `
-Array [
-  "Number",
-  "Boolean",
-  "Number",
-  "Boolean",
-]
-`;
+ 1`] = `"Boolean"`;
 
 exports[`
  fib =
     0 => 1
     1 => 1
     x => ((add (fib ((sub x) 1))) (fib ((sub x) 2)))
- 1`] = `
-Array [
-  "Number -> Number",
-]
-`;
+ 1`] = `"Number -> Number"`;
 
 exports[`
 1 => 2
@@ -126,11 +75,7 @@ x => {
   y = 3
   f = a => 2
   (f y)
-} 1`] = `
-Array [
-  "Number -> Number",
-]
-`;
+} 1`] = `"Number -> Number"`;
 
 exports[`
 x => {
@@ -138,165 +83,66 @@ x => {
   x
 } 1`] = `"x has already been defined"`;
 
-exports[`((() => \`look ma no args\`)) 1`] = `
-Array [
-  "String",
-]
-`;
+exports[`((() => \`look ma no args\`)) 1`] = `"String"`;
 
-exports[`((addZero 1) 2) 1`] = `
-Array [
-  "G",
-]
-`;
+exports[`((addZero 1) 2) 1`] = `"D"`;
 
-exports[`((pair 1) 2) 1`] = `
-Array [
-  "I",
-]
-`;
+exports[`((pair 1) 2) 1`] = `"F"`;
 
-exports[`([1|[2|t]] => t) 1`] = `
-Array [
-  "Array<Number> -> Array<Number>",
-]
-`;
+exports[`([1|[2|t]] => t) 1`] = `"Array<Number> -> Array<Number>"`;
 
 exports[`([1|[true|t]] => t) 1`] = `"Type error: type mismatch"`;
 
 exports[`([h|[true|t]] => [[h 1] t]) 1`] = `"Type error: type mismatch"`;
 
-exports[`([x|[y|t]] => [[x y] t]) 1`] = `
-Array [
-  "Array<Q> -> Array<Array<Q>>",
-]
-`;
+exports[`([x|[y|t]] => [[x y] t]) 1`] = `"Array<K> -> Array<Array<K>>"`;
 
-exports[`(a => 1) 1`] = `
-Array [
-  "E -> Number",
-]
-`;
+exports[`(a => 1) 1`] = `"B -> Number"`;
 
-exports[`(addZero 1) 1`] = `
-Array [
-  "F",
-]
-`;
+exports[`(addZero 1) 1`] = `"C"`;
 
 exports[`(if (true) 1 else \`two\`) 1`] = `"Type error: type mismatch"`;
 
-exports[`(inc 1) 1`] = `
-Array [
-  "Number",
-]
-`;
+exports[`(inc 1) 1`] = `"Number"`;
 
-exports[`(pair 1) 1`] = `
-Array [
-  "H",
-]
-`;
+exports[`(pair 1) 1`] = `"E"`;
 
-exports[`(zero 0) 1`] = `
-Array [
-  "Boolean",
-]
-`;
+exports[`(zero 0) 1`] = `"Boolean"`;
 
-exports[`[1 2 3] 1`] = `
-Array [
-  "Array<Number>",
-]
-`;
+exports[`[1 2 3] 1`] = `"Array<Number>"`;
 
 exports[`[1 2 false] 1`] = `"Type error: type mismatch"`;
 
-exports[`[1|list] => list 1`] = `
-Array [
-  "Array<Number> -> Array<Number>",
-]
-`;
+exports[`[1|list] => list 1`] = `"Array<Number> -> Array<Number>"`;
 
-exports[`\`the\` 1`] = `
-Array [
-  "String",
-]
-`;
+exports[`\`the\` 1`] = `"String"`;
 
 exports[`0 => 0, 1 => true 1`] = `"Type error: type mismatch"`;
 
 exports[`0 => 0, true => 1 1`] = `"Type error: type mismatch"`;
 
-exports[`1 1`] = `
-Array [
-  "Number",
-]
-`;
+exports[`1 1`] = `"Number"`;
 
-exports[`array-destructure.peach 1`] = `
-Array [
-  "Array<B> -> B",
-  "Array<C> -> C",
-  "Array<D> -> D",
-  "Array<Number>",
-  "Array<Number>",
-]
-`;
+exports[`array-destructure.peach 1`] = `"Array<Number>"`;
 
 exports[`f => (f f) 1`] = `"Type error: recursive unification"`;
 
-exports[`f => g => arg => (g (f arg)) 1`] = `
-Array [
-  "(N -> O) -> (O -> P) -> N -> P",
-]
-`;
+exports[`f => g => arg => (g (f arg)) 1`] = `"(H -> I) -> (I -> J) -> H -> J"`;
 
-exports[`fibonacci.peach 1`] = `
-Array [
-  "Number -> Number",
-  "Array<Number>",
-]
-`;
+exports[`fibonacci.peach 1`] = `"Array<Number>"`;
 
-exports[`function.peach 1`] = `
-Array [
-  "A -> A",
-]
-`;
+exports[`function.peach 1`] = `"A -> A"`;
 
 exports[`if (1) 1 else 2 1`] = `"Type error: type mismatch"`;
 
-exports[`if (true) 1 else 2 1`] = `
-Array [
-  "Number",
-]
-`;
+exports[`if (true) 1 else 2 1`] = `"Number"`;
 
-exports[`str.peach 1`] = `
-Array [
-  "Array<String>",
-]
-`;
+exports[`str.peach 1`] = `"Array<String>"`;
 
-exports[`tail-recursion.peach 1`] = `
-Array [
-  "Number -> Number -> Number",
-  "Number -> Number",
-  "Number",
-]
-`;
+exports[`tail-recursion.peach 1`] = `"Number"`;
 
-exports[`true 1`] = `
-Array [
-  "Boolean",
-]
-`;
+exports[`true 1`] = `"Boolean"`;
 
 exports[`x => ((pair (x 3)) (x true)) 1`] = `"Type error: type mismatch"`;
 
-exports[`zero 1`] = `
-Array [
-  "Number -> Boolean",
-]
-`;
+exports[`zero 1`] = `"Number -> Boolean"`;

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -2,7 +2,7 @@
 import { readFileSync } from 'fs'
 import { join } from 'path'
 
-import { getRootEnv } from '../env'
+import { getRootEnv, getTypeEnv } from '../env'
 import parse from '../parser'
 import typeCheck from '../type-checker'
 import interpret from '../interpreter'
@@ -13,9 +13,12 @@ export function fixture (fileName) {
 }
 
 export function run (program) {
+  const env = getRootEnv()
+  const typeEnv = getTypeEnv(env)
+
   const ast = parse(program)
-  typeCheck(ast, getRootEnv())
-  return interpret(ast, getRootEnv())
+  const [typed] = typeCheck(ast, typeEnv)
+  return interpret(typed, getRootEnv())
 }
 
 export function testResult (program, expectedOutput) {

--- a/src/__tests__/type-checker-tests.ts
+++ b/src/__tests__/type-checker-tests.ts
@@ -16,10 +16,9 @@ import {
 function testTypeCheck (code, env = getRootEnv()) {
   test(code, () => {
     const parsed = parse(code)
-    const analysed = typeCheck(parsed, env)
-
-    const types = analysed.map(e => e[0].exprType.toString())
-    expect(types).toMatchSnapshot()
+    const [lastNode] = typeCheck(parsed, env)
+    const type = lastNode.exprType.toString()
+    expect(type).toMatchSnapshot()
   })
 };
 
@@ -34,8 +33,9 @@ function testFixture (fixtureName, env = getRootEnv()) {
   // assert that the no-op analyser makes no changes
   test(fixtureName, () => {
     const parsed = parse(fixture(fixtureName))
-    const analysed = typeCheck(parsed, env)
-    expect(analysed.map(e => e[0].exprType.toString())).toMatchSnapshot()
+    const [lastNode] = typeCheck(parsed, env)
+    const type = lastNode.exprType.toString()
+    expect(type).toMatchSnapshot()
   })
 };
 

--- a/src/__tests__/type-checker-tests.ts
+++ b/src/__tests__/type-checker-tests.ts
@@ -1,9 +1,10 @@
 /* eslint-env jest */
 import parse from '../parser'
 import typeCheck from '../type-checker'
-import { getRootEnv } from '../env'
+import { getRootEnv, getTypeEnv } from '../env'
 import { fixture } from './helpers'
 import { clone } from '../util'
+import { TypedNode, AstNode } from '../node-types'
 
 import {
   TypeVariable,
@@ -13,7 +14,7 @@ import {
   BooleanType
 } from '../types'
 
-function testTypeCheck (code, env = getRootEnv()) {
+function testTypeCheck (code, env = getTypeEnv(getRootEnv())) {
   test(code, () => {
     const parsed = parse(code)
     const [lastNode] = typeCheck(parsed, env)
@@ -22,14 +23,14 @@ function testTypeCheck (code, env = getRootEnv()) {
   })
 };
 
-function testFails (code, env = getRootEnv()) {
+function testFails (code, env = getTypeEnv(getRootEnv())) {
   test(code, () => {
     const parsed = parse(code)
     expect(() => typeCheck(parsed, env)).toThrowErrorMatchingSnapshot()
   })
 }
 
-function testFixture (fixtureName, env = getRootEnv()) {
+function testFixture (fixtureName, env = getTypeEnv(getRootEnv())) {
   // assert that the no-op analyser makes no changes
   test(fixtureName, () => {
     const parsed = parse(fixture(fixtureName))
@@ -86,9 +87,10 @@ testFails(`if (1) 1 else 2`)
 
 // the peach type checker works over nodes with an `exprType` property.
 // helper for creating nodes for synthetic type tests
-function typed (type) {
+function typed (type): TypedNode<AstNode> {
   return {
-    exprType: type
+    exprType: type,
+    type: 'Str'
   }
 }
 

--- a/src/bin/peach.ts
+++ b/src/bin/peach.ts
@@ -7,7 +7,7 @@ const parseArgs = require('minimist')
 
 import { parse } from '..'
 import startRepl from '../repl'
-import { getRootEnv } from '../env'
+import { getRootEnv, getTypeEnv } from '../env'
 import interpret from '../interpreter'
 import typeCheck from '../type-checker'
 
@@ -24,9 +24,11 @@ function read (filePath) {
 function runScript (path) {
   try {
     const ast = parse(read(path))
+    const env = getRootEnv()
+    const typeEnv = getTypeEnv(env)
 
-    typeCheck(ast, getRootEnv())
-    interpret(ast, getRootEnv())
+    const [typedAst] = typeCheck(ast, typeEnv)
+    interpret(typedAst, env)
     return 0
   } catch (e) {
     if (/ENOENT/.test(e.message)) {

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,14 +1,13 @@
 import stdlib from './stdlib'
 import { clone } from './util'
+import { TypeCheckNode } from './node-types'
 
 // Return the default environment for a new program
 export function getRootEnv () {
   return clone(stdlib)
 }
 
-// TODO
-export type TypeEnv = any
+export type TypeEnv = { [name: string]: TypeCheckNode }
 
 // TODO
 export type RuntimeEnv =  any
-

--- a/src/env.ts
+++ b/src/env.ts
@@ -5,3 +5,10 @@ import { clone } from './util'
 export function getRootEnv () {
   return clone(stdlib)
 }
+
+// TODO
+export type TypeEnv = any
+
+// TODO
+export type RuntimeEnv =  any
+

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,13 +1,22 @@
 import stdlib from './stdlib'
-import { clone } from './util'
-import { TypeCheckNode } from './node-types'
+import { clone, extend } from './util'
+import { AstNode, TypedNode, ValueNode } from './node-types'
 
 // Return the default environment for a new program
-export function getRootEnv () {
+export function getRootEnv (): RuntimeEnv {
   return clone(stdlib)
 }
 
-export type TypeEnv = { [name: string]: TypeCheckNode }
+export function getTypeEnv (valueEnv: RuntimeEnv) : TypeEnv {
+  return Object.keys(valueEnv).reduce((env, name) => {
+    env[name] = extend(valueEnv[name], {
+      exprType: valueEnv[name].exprType
+    })
+    return env
+  }, {})
+}
+
+export type TypeEnv = { [name: string]: TypedNode<AstNode> }
 
 // TODO
-export type RuntimeEnv =  any
+export type RuntimeEnv = { [name: string]: ValueNode }

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -3,15 +3,16 @@ import { makeFunction, applyFunction } from './function'
 import { extend, clone } from './util'
 import PeachError from './errors'
 import { getRootEnv } from './env'
+import { Ast } from './node-types'
 
-export default function interpret (ast, rootEnv = getRootEnv()) {
-  const [result, env] = visitAll(ast, rootEnv)
+export default function interpret (ast: Ast, rootEnv = getRootEnv()) {
+  const [result, env] = visit(ast, rootEnv)
   return [result, env]
 }
 
 // Visit each of `nodes` in order, returning the result
 // and environment of the last node.
-function visitAll (nodes, rootEnv) {
+function visitSerial (nodes, rootEnv) {
   return nodes.reduce(([, env], node) => (
     visit(node, env)
   ), [null, rootEnv])
@@ -30,6 +31,10 @@ function visit (node, env) {
 }
 
 const visitors = {
+  Program (node, env, nonGeneric) {
+    return visitSerial(node.expressions, env)
+  },
+
   Def ({ name, value }, env) {
     if (env.hasOwnProperty(name)) {
       throw new PeachError(`${name} has already been defined`)

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -2,13 +2,22 @@
 import { makeFunction, applyFunction } from './function'
 import { extend, clone } from './util'
 import PeachError from './errors'
-import { getRootEnv } from './env'
-import { Ast } from './node-types'
+import { getRootEnv, RuntimeEnv } from './env'
+import {
+  Value, Ast, TypedAst, AstNode, AstProgramNode, AstDefNode, AstNameNode,
+  AstNumeralNode, AstBooleanNode, AstStringNode, AstCallNode, AstArrayNode,
+  AstDestructuredArrayNode, AstFunctionNode, AstIfNode,
+  isAstNameNode
+} from './node-types'
 
-export default function interpret (ast: Ast, rootEnv = getRootEnv()) {
+export type InterpreterResult = [Value, RuntimeEnv]
+
+export default function interpret (ast: TypedAst, rootEnv: RuntimeEnv = getRootEnv()): InterpreterResult {
   const [result, env] = visit(ast, rootEnv)
   return [result, env]
 }
+
+type Visitor = (node: AstNode, env: RuntimeEnv) => InterpreterResult
 
 // Visit each of `nodes` in order, returning the result
 // and environment of the last node.
@@ -18,24 +27,23 @@ function visitSerial (nodes, rootEnv) {
   ), [null, rootEnv])
 }
 
-function visitUnknown (node) {
+function visitUnknown (node, env): InterpreterResult {
   console.log(JSON.stringify(node, null, 2))
   throw new PeachError(`unknown node type: ${node.type}`)
 }
 
-function visit (node, env) {
+function visit (node: AstNode, env: RuntimeEnv) {
   const visitor = visitors[node.type] || visitUnknown
 
-  // console.log(`trace: ${node.type} ${node.name || ''}`)
   return visitor(node, env)
 }
 
-const visitors = {
-  Program (node, env, nonGeneric) {
+const visitors: { [nodeType: string]: Visitor } = {
+  Program (node: AstProgramNode, env) {
     return visitSerial(node.expressions, env)
   },
 
-  Def ({ name, value }, env) {
+  Def ({ name, value }: AstDefNode, env) {
     if (env.hasOwnProperty(name)) {
       throw new PeachError(`${name} has already been defined`)
     }
@@ -52,7 +60,7 @@ const visitors = {
     return [result, env]
   },
 
-  Name ({ name }, env) {
+  Name ({ name }: AstNameNode, env) {
     if (!(name in env)) {
       throw new PeachError(`${name} is not defined`)
     }
@@ -60,35 +68,35 @@ const visitors = {
     return [env[name], env]
   },
 
-  Numeral ({ value }, env) {
+  Numeral ({ value }: AstNumeralNode, env) {
     return [value, env]
   },
 
-  Bool ({ value }, env) {
+  Bool ({ value }: AstBooleanNode, env) {
     return [value, env]
   },
 
-  Str ({ value }, env) {
+  Str ({ value }: AstStringNode, env) {
     return [value, env]
   },
 
-  Call ({ fn, args }, env) {
+  Call ({ fn, args }: AstCallNode, env) {
     const [fnResult] = visit(fn, env)
     const argResults = args.map((arg) => visit(arg, env)[0])
     return [applyFunction(fnResult, argResults), env]
   },
 
-  Array ({ values }, env) {
+  Array ({ values }: AstArrayNode, env) {
     const results = values.map((value) => visit(value, env)[0])
     return [results, env]
   },
 
-  Fn (node, env) {
+  Fn (node: AstFunctionNode, env) {
     const fn = makeFunction(node, env, visit)
     return [fn, env]
   },
 
-  If ({ condition, ifBranch, elseBranch }, env) {
+  If ({ condition, ifBranch, elseBranch }: AstIfNode, env) {
     const [testResult] = visit(condition, env)
     const branch = (testResult) ? ifBranch : elseBranch
 

--- a/src/node-types.ts
+++ b/src/node-types.ts
@@ -1,0 +1,14 @@
+import { Type } from './types'
+
+export interface AstNode {
+  type: string
+}
+
+export interface TypeCheckNode extends AstNode {
+  exprType: Type
+}
+
+// TODO add a `program` prodction so that AST is a single AstNode.
+// That will need a refresh of all parser tests, so it will be a separate change.
+export type Ast = Array<AstNode>
+export type TypedAst = Array<TypeCheckNode>

--- a/src/node-types.ts
+++ b/src/node-types.ts
@@ -8,7 +8,5 @@ export interface TypeCheckNode extends AstNode {
   exprType: Type
 }
 
-// TODO add a `program` prodction so that AST is a single AstNode.
-// That will need a refresh of all parser tests, so it will be a separate change.
-export type Ast = Array<AstNode>
-export type TypedAst = Array<TypeCheckNode>
+export type Ast = AstNode
+export type TypedAst = TypeCheckNode

--- a/src/node-types.ts
+++ b/src/node-types.ts
@@ -4,10 +4,90 @@ export interface AstNode {
   type: string
 }
 
-export interface TypeCheckNode {
-  exprType: Type,
-  node: AstNode
+export interface AstProgramNode {
+  type: string,
+  expressions: AstNode[]
 }
 
-export type Ast = AstNode
-export type TypedAst = TypeCheckNode
+export interface AstDefNode {
+  type: string,
+  name: string,
+  value: AstNode
+}
+
+export interface AstNameNode {
+  type: string,
+  name: string
+}
+
+export interface AstNumeralNode {
+  type: string,
+  value: number
+}
+
+export interface AstBooleanNode {
+  type: string,
+  value: boolean
+}
+
+export interface AstStringNode {
+  type: string,
+  value: string
+}
+
+export interface AstCallNode {
+  type: string,
+  fn: AstFunctionNode,
+  args: AstNode[]
+}
+
+export interface AstArrayNode {
+  type: string,
+  values: AstNode[]
+}
+
+export interface AstDestructuredArrayNode {
+  type: string,
+  head: AstNode,
+  tail: AstNode
+}
+
+export interface AstFunctionNode {
+  type: string,
+  clauses: AstFunctionClauseNode[]
+}
+
+export interface AstFunctionClauseNode {
+  type: string,
+  pattern: AstNode[],
+  body: AstNode[]
+}
+
+export interface AstIfNode {
+  type: string,
+  condition: AstNode,
+  ifBranch: AstNode,
+  elseBranch: AstNode
+}
+
+export interface Typed {
+  exprType: Type
+}
+
+export type TypedNode<T extends AstNode> = T & Typed
+
+export function isAstNameNode (node: AstNode): node is AstNameNode {
+  return node.type === 'Name'
+}
+
+export type Ast = AstProgramNode
+export type TypedAst = TypedNode<Ast>
+
+// TODO
+export type Value = any
+
+export interface ValueNode {
+  exprType: Type,
+  node: AstNode,
+  value: Value
+}

--- a/src/node-types.ts
+++ b/src/node-types.ts
@@ -4,8 +4,9 @@ export interface AstNode {
   type: string
 }
 
-export interface TypeCheckNode extends AstNode {
-  exprType: Type
+export interface TypeCheckNode {
+  exprType: Type,
+  node: AstNode
 }
 
 export type Ast = AstNode

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,11 +1,12 @@
 import { readFileSync } from 'fs'
-import  { join } from 'path'
+import { join } from 'path'
 import { generate } from 'pegjs'
+import { Ast } from './node-types'
 
 const parserSource = readFileSync(join(__dirname, 'peach.pegjs'), 'utf8')
 const parser = generate(parserSource)
 
-export default function parse (source) {
+export default function parse (source: string): Ast {
   const ast = parser.parse(source)
   // console.log(JSON.stringify(ast))
   return ast

--- a/src/peach.pegjs
+++ b/src/peach.pegjs
@@ -3,7 +3,10 @@ start
 
 // a program is a list of newline-delimted expressions
 program = head:expression tail:(eol e:expression { return e })* {
-  return [head, ...tail];
+  return {
+    type: "Program",
+    expressions: [head, ...tail]
+  }
 }
 
 expression

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -4,7 +4,7 @@ import { start } from 'repl'
 const { Recoverable } = require('repl')
 // /FIXME
 
-import { getRootEnv } from './env'
+import { getRootEnv, getTypeEnv, RuntimeEnv, TypeEnv } from './env'
 import interpret from './interpreter'
 import typeCheck from './type-checker'
 import { parse, PeachError } from '.'
@@ -17,17 +17,15 @@ export default function startRepl (options, onExit) {
   // remember the environment from each command to pass to the next
   // remember a separate environment for type checking, because the REPL
   // needs to continually type check the new input against existing definitions
-  // TODO type annotations
-  let lastEnv = getRootEnv()      // name -> value
-  let lastTypeEnv = getRootEnv()  // name -> typed AST node
+  let lastEnv: RuntimeEnv = getRootEnv()
+  let lastTypeEnv: TypeEnv = getTypeEnv(lastEnv)
 
   function evalPeach (src, context, filename, callback) {
     try {
       const ast = parse(src)
 
-      const checked = typeCheck(ast, lastTypeEnv)
-      const [typed, nextTypeEnv] = checked
-      const [result, nextEnv] = interpret(ast, lastEnv)
+      const [typed, nextTypeEnv] = typeCheck(ast, lastTypeEnv)
+      const [result, nextEnv] = interpret(typed, lastEnv)
 
       lastEnv = nextEnv
       lastTypeEnv = nextTypeEnv

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -5,8 +5,8 @@ const { Recoverable } = require('repl')
 // /FIXME
 
 import { getRootEnv } from './env'
-import interpret from "./interpreter"
-import typeCheck from "./type-checker"
+import interpret from './interpreter'
+import typeCheck from './type-checker'
 import { parse, PeachError } from '.'
 
 const { version } = require('../package.json')
@@ -18,7 +18,7 @@ export default function startRepl (options, onExit) {
   // remember a separate environment for type checking, because the REPL
   // needs to continually type check the new input against existing definitions
   // TODO type annotations
-  let lastEnv = getRootEnv()  ;    // name -> value
+  let lastEnv = getRootEnv()      // name -> value
   let lastTypeEnv = getRootEnv()  // name -> typed AST node
 
   function evalPeach (src, context, filename, callback) {
@@ -26,7 +26,7 @@ export default function startRepl (options, onExit) {
       const ast = parse(src)
 
       const checked = typeCheck(ast, lastTypeEnv)
-      const [[typed, nextTypeEnv]] = checked
+      const [typed, nextTypeEnv] = checked
       const [result, nextEnv] = interpret(ast, lastEnv)
 
       lastEnv = nextEnv

--- a/src/type-checker.ts
+++ b/src/type-checker.ts
@@ -1,5 +1,7 @@
 import { create, extend } from './util'
 import PeachError from './errors'
+import { Ast, TypeCheckNode } from './node-types'
+import { TypeEnv } from './env'
 import {
   TypeVariable,
   TypeOperator,
@@ -10,9 +12,13 @@ import {
   makeFunctionType
 } from './types'
 
-export default function analyse (rawAst, typedEnv, nonGeneric = new Set()) {
+export default function analyse (rawAst: Ast, typedEnv: TypeEnv, nonGeneric = new Set()): TypeCheckResult {
   return visitAll(rawAst, typedEnv, nonGeneric)
 }
+
+// TODO add the Program node type, so SingleTypeCheckResult becomes the only TypeCheckResult
+export type TypeCheckResult = Array<SingleTypeCheckResult>
+type SingleTypeCheckResult = [TypeCheckNode, TypeEnv]
 
 function visitAll (nodes, env, nonGeneric) {
   return nodes.map(node => visit(node, env, nonGeneric))

--- a/src/type-checker.ts
+++ b/src/type-checker.ts
@@ -12,17 +12,11 @@ import {
   makeFunctionType
 } from './types'
 
-export default function analyse (rawAst: Ast, typedEnv: TypeEnv, nonGeneric = new Set()): TypeCheckResult {
-  return visitAll(rawAst, typedEnv, nonGeneric)
+export default function analyse (ast: Ast, typedEnv: TypeEnv, nonGeneric = new Set()): TypeCheckResult {
+  return visit(ast, typedEnv, nonGeneric)
 }
 
-// TODO add the Program node type, so SingleTypeCheckResult becomes the only TypeCheckResult
-export type TypeCheckResult = Array<SingleTypeCheckResult>
-type SingleTypeCheckResult = [TypeCheckNode, TypeEnv]
-
-function visitAll (nodes, env, nonGeneric) {
-  return nodes.map(node => visit(node, env, nonGeneric))
-}
+export type TypeCheckResult = [TypeCheckNode, TypeEnv]
 
 function visitSerial (nodes, env, nonGeneric) {
   return nodes.reduce(([, nextEnv], nextNode) =>
@@ -37,6 +31,10 @@ function visit (node, env, nonGeneric) {
 }
 
 const visitors = {
+  Program (node, env, nonGeneric) {
+    return visitSerial(node.expressions, env, nonGeneric)
+  },
+
   Def (node, env, nonGeneric) {
     if (env.hasOwnProperty(node.name)) {
       throw new PeachError(`${node.name} has already been defined`)

--- a/src/util.ts
+++ b/src/util.ts
@@ -12,7 +12,11 @@ export function create (proto, properties = null) {
 }
 
 export function restAndLast (arr) {
-  const [last] = arr.slice(-1)
+  const _last = last(arr)
   const rest = arr.slice(0, -1)
-  return [rest, last]
+  return [rest, _last]
+}
+
+export function last (arr) {
+  return arr[arr.length - 1]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
         "module": "commonjs",
         "moduleResolution": "node",
         "outDir": "./dist",
-        "target": "es2017"
+        "target": "es2017",
+        "sourceMap": true
     },
     "include": [
         "./src/**/*"


### PR DESCRIPTION
Start to add TypeScript type annotations to the type checker and interpreter.

# Rough plan
* [x] Type `parse` and `typeCheck` with `AstNode` and `TypedAstNode`
* [x]  Add a `Program` production to simplify AST and `typeCheck` type
* [x]  Add types for `TypeEnv` and `RuntimeEnv`
* [x]  Type `interpret`

# To do later
* Work out an elegant way to make `exprType` available  to the interpreter - see dd13a54455431ac3159ab54525fa175f5a6dea16
* Type runtime values
* A visitor pattern that works better with TypeScript's type system. Then we can avoid annotations in visitor functions.