### PR TITLE
Add a second IR for typed AST Nodes

### DIFF
--- a/src/__tests__/type-checker-tests.ts
+++ b/src/__tests__/type-checker-tests.ts
@@ -31,7 +31,6 @@ function testFails (code, env = getTypeEnv(getRootEnv())) {
 }
 
 function testFixture (fixtureName, env = getTypeEnv(getRootEnv())) {
-  // assert that the no-op analyser makes no changes
   test(fixtureName, () => {
     const parsed = parse(fixture(fixtureName))
     const [lastNode] = typeCheck(parsed, env)
@@ -87,7 +86,7 @@ testFails(`if (1) 1 else 2`)
 
 // the peach type checker works over nodes with an `exprType` property.
 // helper for creating nodes for synthetic type tests
-function typed (type): TypedNode<AstNode> {
+function typed (type): TypedNode {
   return {
     exprType: type,
     type: 'Str'

--- a/src/env.ts
+++ b/src/env.ts
@@ -7,7 +7,7 @@ export function getRootEnv (): RuntimeEnv {
   return clone(stdlib)
 }
 
-export function getTypeEnv (valueEnv: RuntimeEnv) : TypeEnv {
+export function getTypeEnv (valueEnv: RuntimeEnv): TypeEnv {
   return Object.keys(valueEnv).reduce((env, name) => {
     env[name] = extend(valueEnv[name], {
       exprType: valueEnv[name].exprType
@@ -16,7 +16,7 @@ export function getTypeEnv (valueEnv: RuntimeEnv) : TypeEnv {
   }, {})
 }
 
-export type TypeEnv = { [name: string]: TypedNode<AstNode> }
+export type TypeEnv = { [name: string]: TypedNode }
 
 // TODO
 export type RuntimeEnv = { [name: string]: ValueNode }

--- a/src/node-types.ts
+++ b/src/node-types.ts
@@ -1,12 +1,29 @@
 import { Type } from './types'
 
+//
+// intermediate representations
+// #35 explains why there are several IRs.
+//
+export type Ast = AstProgramNode
+export type TypedAst = TypedProgramNode
+
+// Ast*: parser output. Typed raw AST nodes.
 export interface AstNode {
   type: string
+}
+
+// Typed*: type checker output. AST nodes augmented with Peach static types.
+export interface TypedNode extends AstNode {
+  exprType: Type
 }
 
 export interface AstProgramNode {
   type: string,
   expressions: AstNode[]
+}
+
+export interface TypedProgramNode extends AstProgramNode, TypedNode {
+  expressions: TypedNode[]
 }
 
 export interface AstDefNode {
@@ -15,25 +32,37 @@ export interface AstDefNode {
   value: AstNode
 }
 
+export interface TypedDefNode extends AstDefNode, TypedNode {
+  value: TypedNode
+}
+
 export interface AstNameNode {
   type: string,
   name: string
 }
+
+export interface TypedNameNode extends AstNameNode, TypedNode { }
 
 export interface AstNumeralNode {
   type: string,
   value: number
 }
 
+export interface TypedNumeralNode extends AstNumeralNode, TypedNode { }
+
 export interface AstBooleanNode {
   type: string,
   value: boolean
 }
 
+export interface TypedBooleanNode extends AstBooleanNode, TypedNode { }
+
 export interface AstStringNode {
   type: string,
   value: string
 }
+
+export interface TypedStringNode extends AstStringNode, TypedNode { }
 
 export interface AstCallNode {
   type: string,
@@ -41,9 +70,18 @@ export interface AstCallNode {
   args: AstNode[]
 }
 
+export interface TypedCallNode extends AstCallNode, TypedNode {
+  fn: TypedFunctionNode,
+  args: TypedNode[]
+}
+
 export interface AstArrayNode {
   type: string,
   values: AstNode[]
+}
+
+export interface TypedArrayNode extends AstArrayNode, TypedNode {
+  values: TypedNode[]
 }
 
 export interface AstDestructuredArrayNode {
@@ -52,15 +90,29 @@ export interface AstDestructuredArrayNode {
   tail: AstNode
 }
 
+export interface TypedDestructuredArrayNode extends AstDestructuredArrayNode, TypedNode {
+  head: TypedNode,
+  tail: TypedNode
+}
+
 export interface AstFunctionNode {
   type: string,
   clauses: AstFunctionClauseNode[]
+}
+
+export interface TypedFunctionNode extends AstFunctionNode, TypedNode {
+  clauses: TypedFunctionClauseNode[]
 }
 
 export interface AstFunctionClauseNode {
   type: string,
   pattern: AstNode[],
   body: AstNode[]
+}
+
+export interface TypedFunctionClauseNode extends AstFunctionClauseNode, TypedNode {
+  pattern: TypedNode[],
+  body: TypedNode[]
 }
 
 export interface AstIfNode {
@@ -70,20 +122,23 @@ export interface AstIfNode {
   elseBranch: AstNode
 }
 
-export interface Typed {
-  exprType: Type
+export interface TypedIfNode extends AstIfNode, TypedNode {
+  condition: TypedNode,
+  ifBranch: TypedNode,
+  elseBranch: TypedNode
 }
 
-export type TypedNode<T extends AstNode> = T & Typed
-
+//
+// Type guard functions
+//
 export function isAstNameNode (node: AstNode): node is AstNameNode {
   return node.type === 'Name'
 }
 
-export type Ast = AstProgramNode
-export type TypedAst = TypedNode<Ast>
-
+//
+// Runtime values
 // TODO
+//
 export type Value = any
 
 export interface ValueNode {


### PR DESCRIPTION
In #34 I came across part of ["the AST typing problem"](http://lambda-the-ultimate.org/node/4170).

I want each compiler stage to map an input AST into a transformed AST. The only transforming stage at the moment is the type checker, which maps Raw AST Nodes into Typed AST Nodes. There could be others in the future.

That's difficult with static types, because we want to change the shape of each Node type. For example:

```typescript
interface AstDefNode {
  type: string,
  name: string,
  value: AstNode
}
```

To add type information to this node, there are two changes: Add an `exprType: Type` - the actual type checker output for this node; and change the `value` to be a typed node as well:

```typescript
interface TypedDefNode {
  type: string,
  name: string,
  exprType: Type,
  value: TypedNode
}
```

The question is: what is the right way to model Node types of different shapes in a statically typed language?

There seem to be three general solutions:

1. Extend the above examples so that we have N IRs - a full set of Node types for the raw AST and typed AST. If we add another transforming stage, we'll add another set of Node types. This is simple and works well with the current codebase, but adds a lot of duplication and may not scale as the compiler grows.

2. Add optional fields to the base `AstNode` interface so that all of the possible transformations may be performed on a single type (I think GWT does this). This works well with the current codebase but loses type safety: a stage before the type checker could try to access `node.exprType`, which is a null reference.

3. Store transformation data in external maps (OCaml does this). The type checker would return something like a `WeakMap<AstNode, Type>`, which later stages can use to get rich data. All stages share the same AST. This is neat, but would involve quite a lot of refactoring.

This PR implements __1__. It's pragmatic - there are only 2 IRs, and I don't have plans to add any other stages yet, and it doesn't need much refactoring. If it causes maintainability issues i'll look again at 3.
