### PR TITLE
Use tagged unions for static typing in the type checker and interpreter

### DIFF
--- a/src/__tests__/type-checker-tests.ts
+++ b/src/__tests__/type-checker-tests.ts
@@ -89,7 +89,8 @@ testFails(`if (1) 1 else 2`)
 function typed (type): TypedNode {
   return {
     exprType: type,
-    type: 'Str'
+    type: 'Str',
+    value: 'dummy'
   }
 }
 

--- a/src/function.ts
+++ b/src/function.ts
@@ -1,7 +1,8 @@
-import unify from "./unify"
-import { create, restAndLast } from "./util"
-import PeachError from "./errors"
-import { makeFunctionType } from "./types"
+import unify from './unify'
+import { create, restAndLast } from './util'
+import PeachError from './errors'
+import { makeFunctionType } from './types'
+import { TypedFunctionNode } from './node-types'
 
 const ANONYMOUS = 'anonymous'
 
@@ -9,7 +10,7 @@ const ANONYMOUS = 'anonymous'
 // https://jsfiddle.net/v6j4a9qh/6/
 
 // Make a user-defined function from an AST node
-export function  makeFunction (functionNode, parentEnv, visit) {
+export function makeFunction (functionNode: TypedFunctionNode, parentEnv, visit) {
   const { clauses } = functionNode
   const name = getName(functionNode)
 
@@ -33,7 +34,7 @@ export function  makeFunction (functionNode, parentEnv, visit) {
         //  check if it's a tail call. If so return a thunk so we can use the trampoline
         //  pattern to avoid call stack overflow. As above - this test needs refining
         // to include any terminal expression in a function.
-        if (isFunctionCall(lastNode)) {
+        if (lastNode.type === 'Call') {
           const resolvedFunction = visit(lastNode.fn, env)[0]
           if (resolvedFunction === pFunction) {
             // evaluate the re-entrant args without recursing to `visit(lastNode)`
@@ -90,7 +91,6 @@ export function applyFunction (pFunction, args) {
     : curry(pFunction, args)
 }
 
-
 function getName (node) {
   return node.boundName || ANONYMOUS
 }
@@ -119,8 +119,4 @@ function curry (pFunction, appliedArgs) {
     arity: pFunction.arity - appliedArgs.length,
     call: pFunction.call.bind(null, ...appliedArgs)
   })
-}
-
-function isFunctionCall (node) {
-  return node.type === 'Call'
 }

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -6,8 +6,7 @@ import { getRootEnv, RuntimeEnv } from './env'
 import {
   Value, TypedAst, TypedNode, TypedProgramNode, TypedDefNode, TypedNameNode,
   TypedNumeralNode, TypedBooleanNode, TypedStringNode, TypedCallNode, TypedArrayNode,
-  TypedDestructuredArrayNode, TypedFunctionNode, TypedIfNode,
-  isAstNameNode
+  TypedDestructuredArrayNode, TypedFunctionNode, TypedIfNode
 } from './node-types'
 
 export type InterpreterResult = [Value, RuntimeEnv]

--- a/src/node-types.ts
+++ b/src/node-types.ts
@@ -8,131 +8,152 @@ export type Ast = AstProgramNode
 export type TypedAst = TypedProgramNode
 
 // Ast*: parser output. Typed raw AST nodes.
-export interface AstNode {
+export interface AstBaseNode {
   type: string
 }
 
+export type AstNode
+  = AstProgramNode
+  | AstDefNode
+  | AstNameNode
+  | AstNumeralNode
+  | AstBooleanNode
+  | AstStringNode
+  | AstCallNode
+  | AstArrayNode
+  | AstDestructuredArrayNode
+  | AstFunctionNode
+  | AstFunctionClauseNode
+  | AstIfNode
+
 // Typed*: type checker output. AST nodes augmented with Peach static types.
-export interface TypedNode extends AstNode {
+export type TypedNode
+  = TypedProgramNode
+  | TypedDefNode
+  | TypedNameNode
+  | TypedNumeralNode
+  | TypedBooleanNode
+  | TypedStringNode
+  | TypedCallNode
+  | TypedArrayNode
+  | TypedDestructuredArrayNode
+  | TypedFunctionNode
+  | TypedFunctionClauseNode
+  | TypedIfNode
+
+export interface Typed {
   exprType: Type
 }
 
 export interface AstProgramNode {
-  type: string,
+  type: 'Program',
   expressions: AstNode[]
 }
 
-export interface TypedProgramNode extends AstProgramNode, TypedNode {
+export interface TypedProgramNode extends AstProgramNode, Typed {
   expressions: TypedNode[]
 }
 
 export interface AstDefNode {
-  type: string,
+  type: 'Def',
   name: string,
   value: AstNode
 }
 
-export interface TypedDefNode extends AstDefNode, TypedNode {
+export interface TypedDefNode extends AstDefNode, Typed {
   value: TypedNode
 }
 
 export interface AstNameNode {
-  type: string,
+  type: 'Name',
   name: string
 }
 
-export interface TypedNameNode extends AstNameNode, TypedNode { }
+export interface TypedNameNode extends AstNameNode, Typed { }
 
 export interface AstNumeralNode {
-  type: string,
+  type: 'Numeral',
   value: number
 }
 
-export interface TypedNumeralNode extends AstNumeralNode, TypedNode { }
+export interface TypedNumeralNode extends AstNumeralNode, Typed { }
 
 export interface AstBooleanNode {
-  type: string,
+  type: 'Bool',
   value: boolean
 }
 
-export interface TypedBooleanNode extends AstBooleanNode, TypedNode { }
+export interface TypedBooleanNode extends AstBooleanNode, Typed { }
 
 export interface AstStringNode {
-  type: string,
+  type: 'Str',
   value: string
 }
 
-export interface TypedStringNode extends AstStringNode, TypedNode { }
+export interface TypedStringNode extends AstStringNode, Typed { }
 
 export interface AstCallNode {
-  type: string,
-  fn: AstFunctionNode,
+  type: 'Call',
+  fn: AstNode,
   args: AstNode[]
 }
 
-export interface TypedCallNode extends AstCallNode, TypedNode {
+export interface TypedCallNode extends AstCallNode, Typed {
   fn: TypedFunctionNode,
   args: TypedNode[]
 }
 
 export interface AstArrayNode {
-  type: string,
+  type: 'Array',
   values: AstNode[]
 }
 
-export interface TypedArrayNode extends AstArrayNode, TypedNode {
+export interface TypedArrayNode extends AstArrayNode, Typed {
   values: TypedNode[]
 }
 
 export interface AstDestructuredArrayNode {
-  type: string,
+  type: 'DestructuredArray',
   head: AstNode,
   tail: AstNode
 }
 
-export interface TypedDestructuredArrayNode extends AstDestructuredArrayNode, TypedNode {
+export interface TypedDestructuredArrayNode extends AstDestructuredArrayNode, Typed {
   head: TypedNode,
   tail: TypedNode
 }
 
 export interface AstFunctionNode {
-  type: string,
+  type: 'Fn',
   clauses: AstFunctionClauseNode[]
 }
 
-export interface TypedFunctionNode extends AstFunctionNode, TypedNode {
+export interface TypedFunctionNode extends AstFunctionNode, Typed {
   clauses: TypedFunctionClauseNode[]
 }
 
 export interface AstFunctionClauseNode {
-  type: string,
+  type: 'FunctionClause',
   pattern: AstNode[],
   body: AstNode[]
 }
 
-export interface TypedFunctionClauseNode extends AstFunctionClauseNode, TypedNode {
+export interface TypedFunctionClauseNode extends AstFunctionClauseNode, Typed {
   pattern: TypedNode[],
   body: TypedNode[]
 }
 
 export interface AstIfNode {
-  type: string,
+  type: 'If',
   condition: AstNode,
   ifBranch: AstNode,
   elseBranch: AstNode
 }
 
-export interface TypedIfNode extends AstIfNode, TypedNode {
+export interface TypedIfNode extends AstIfNode, Typed {
   condition: TypedNode,
   ifBranch: TypedNode,
   elseBranch: TypedNode
-}
-
-//
-// Type guard functions
-//
-export function isAstNameNode (node: AstNode): node is AstNameNode {
-  return node.type === 'Name'
 }
 
 //

--- a/src/type-checker.ts
+++ b/src/type-checker.ts
@@ -8,8 +8,7 @@ import {
   AstDestructuredArrayNode, AstFunctionNode, AstIfNode,
   TypedAst, TypedNode, TypedProgramNode, TypedDefNode, TypedNameNode,
   TypedNumeralNode, TypedBooleanNode, TypedStringNode, TypedCallNode, TypedArrayNode,
-  TypedDestructuredArrayNode, TypedFunctionNode, TypedIfNode,
-  isAstNameNode
+  TypedDestructuredArrayNode, TypedFunctionNode, TypedFunctionClauseNode, TypedIfNode
 } from './node-types'
 
 import {
@@ -24,9 +23,6 @@ import {
 } from './types'
 
 export default function analyse (ast: Ast, typedEnv: TypeEnv): TypeCheckResult<TypedAst> {
-  // TODO the cast is needed because of the visitor lookup by Ast Node type. It could
-  // be avoided by refactoring AstNodes to classes and using `if (node instanceof AstXyzNode)`
-  // guards, or `isAstAyzNode` function guards.
   return visit(ast, typedEnv, new Set<Type>()) as TypeCheckResult<TypedAst>
 }
 
@@ -42,196 +38,229 @@ function visitSerial (nodes: AstNode[], env: TypeEnv, nonGeneric: Set<Type>): Ty
   , initialState)
 }
 
-function visitAll (nodes, rootEnv, nonGeneric) {
-  return nodes.reduce(([nodes, env], node) => {
+// Visit a list of nodes, each in the returned env of the previous step.
+// Return an array of their resolved types and the last environment.
+// TODO DRY visitSerial to use this function
+// TODO static type for `nodes` - the callback throws type errors for nodes: AstNode[]
+function visitAll (nodes: any[], rootEnv: TypeEnv, nonGeneric: Set<any>): [TypedNode[], TypeEnv] {
+  const initialState: [TypedNode[], TypeEnv] = [[], rootEnv]
+
+  return nodes.reduce(([nodes, env]: [TypedNode[], TypeEnv], node) => {
     const [outNode, outEnv] = visit(node, env, nonGeneric)
     return [[...nodes, outNode], outEnv]
-  }, [[], rootEnv])
+  }, initialState)
 }
 
-function visit (node: AstNode, env: TypeEnv, nonGeneric: Set<Type>) {
-  const visitor = visitors[node.type]
-  return visitor(node, env, nonGeneric)
-}
+function visit (node: AstNode, env: TypeEnv, nonGeneric: Set<Type>): TypeCheckResult<TypedNode> {
+  // console.log(`TRACE typecheck: ${node.type}\n${JSON.stringify(node)}`)
 
-const visitors: { [nodeType: string]: TypeCheckVisitor<TypedNode> } = {
-  Program (node: AstProgramNode, env, nonGeneric) {
-    const [expressions, finalEnv] = visitAll(node.expressions, env, nonGeneric)
-    const programType = typeOf(last(expressions))
-
-    const typedNode = typed({ ...node, expressions }, programType)
-    return [typedNode, finalEnv]
-  },
-
-  Def (node: AstDefNode, env, nonGeneric) {
-    if (env.hasOwnProperty(node.name)) {
-      throw new PeachError(`${node.name} has already been defined`)
-    }
-
-    // allow for recursive binding by binding ahead of evaluating the child
-    // analogous to Lisp's letrec, but in the enclosing scope.
-    // TODO immutable env
-    const t = new TypeVariable()
-    env[node.name] = typed(node, t)
-
-    // if we are defining a function, mark the new identifier as
-    //  non-generic inside the evaluation of the body.
-    const innerNonGeneric = (node.value.type === 'Fn')
-      ? new Set([...nonGeneric, t])
-      : nonGeneric
-
-    const [value] = visit(node.value, env, innerNonGeneric)
-    unify(typeOf(value), t)
-
-    const typedNode = typed({ ...node, value }, t)
-    return [typedNode, env]
-  },
-
-  // identifier
-  Name (node: AstNameNode, env, nonGeneric) {
-    if (!(node.name in env)) {
-      throw new PeachError(`${node.name} is not defined`)
-    }
-
-    const envType = typeOf(env[node.name])
-    const freshType = fresh(envType, nonGeneric)
-
-    return [typed(node, freshType), env]
-  },
-
-  Numeral (node: AstNumeralNode, env) {
-    return [typed(node, NumberType), env]
-  },
-
-  Bool (node: AstBooleanNode, env) {
-    return [typed(node, BooleanType), env]
-  },
-
-  Str (node: AstStringNode, env) {
-    return [typed(node, StringType), env]
-  },
-
-  Call (node: AstCallNode, env, nonGeneric) {
-    const [fn] = visit(node.fn, env, nonGeneric)
-    const args = node.args.map((arg) => visit(arg, env, nonGeneric)[0])
-
-    const returnType = new TypeVariable()
-    const callFunctionType = makeFunctionType(typesOf(args), returnType)
-
-    unify(callFunctionType, typeOf(fn))
-
-    const typedNode = typed({ ...node, args }, returnType)
-    return [typedNode, env]
-  },
-
-  Array (node: AstArrayNode, env, nonGeneric) {
-    let itemType
-    let typedValues
-
-    if (node.values.length > 0) {
-      typedValues = node.values.map((value) => visit(value, env, nonGeneric)[0])
-      const types = typedValues.map(value => value.exprType)
-
-      // arrays are homogenous: all items must have the same type
-      unifyAll(types)
-      itemType = types[0]
-    } else {
-      itemType = new TypeVariable()
-      typedValues = []
-    }
-
-    const arrayType = new ArrayType(itemType)
-    const typedNode = typed({ ...node, values: typedValues }, arrayType)
-
-    return [typedNode, env]
-  },
-
-  DestructuredArray (node: AstDestructuredArrayNode, env, nonGeneric) {
-    const { head, tail } = node
-
-    const boundHeadType = new TypeVariable()
-    const boundTailType = new ArrayType(new TypeVariable())
-
-    // TODO immutable env
-    if (isAstNameNode(head)) {
-      env[head.name] = typed(head, boundHeadType)
-      nonGeneric.add(boundHeadType)
-    }
-
-    if (isAstNameNode(tail)) {
-      env[tail.name] = typed(tail, boundTailType)
-      nonGeneric.add(boundTailType)
-    }
-
-    const [typedHead] = visit(head, env, nonGeneric)
-    const [typedTail] = visit(tail, env, nonGeneric)
-
-    const headType = typeOf(typedHead)
-    const tailType = typeOf(typedTail)
-
-    // the tail must be a array of the head type
-    // the usage types of head and tail must match the declared types
-    unify(boundHeadType, boundTailType.getType())
-    unify(headType, boundHeadType)
-    unify(tailType, boundTailType)
-
-    const typedNode = typed({ ...node, head: typedHead, tail: typedTail }, tailType)
-    return [typed(node, tailType), env]
-  },
-
-  Fn (node: AstFunctionNode, parentEnv, outerNonGeneric) {
-    // TODO clauses must be exhaustive - functions must accept any input of the right types
-    const clauses = node.clauses.map((clauseNode) => {
-      const nonGeneric = new Set([...outerNonGeneric])
-      const env = create(parentEnv)
-
-      // get the array of arg types
-      const patternTypes = clauseNode.pattern.map(argNode => {
-        // If this is a `Name` arg, define it in the function's arguments environment.
-        // if it's a destructured array we need to recursively define any named children,
-        // so visiting the node will define its names.
-        if (isAstNameNode(argNode)) {
-          const argType = new TypeVariable()
-          env[argNode.name] = typed(argNode, argType)
-          nonGeneric.add(argType)
-        }
-
-        const [typedArgNode] = visit(argNode, env, nonGeneric)
-        return typeOf(typedArgNode)
-      })
-
-      const [lastBodyNode] = visitSerial(clauseNode.body, env, nonGeneric)
-      const returnType = prune(typeOf(lastBodyNode))
-
-      const clauseType = makeFunctionType(patternTypes, returnType)
-      return typed(clauseNode, clauseType)
-    })
-
-    // all clauses must have tbe same type
-    unifyAll(typesOf(clauses))
-
-    const typedNode = typed({ ...node, clauses }, typeOf(clauses[0]))
-    return [typedNode, parentEnv]
-  },
-
-  If (node: AstIfNode, env, nonGeneric) {
-    const [condition] = visit(node.condition, env, nonGeneric)
-    const [ifBranch] = visit(node.ifBranch, env, nonGeneric)
-    const [elseBranch] = visit(node.elseBranch, env, nonGeneric)
-
-    unify(typeOf(condition), BooleanType)
-    unify(typeOf(ifBranch), typeOf(elseBranch))
-
-    const typedNode = typed({ ...node, condition, ifBranch, elseBranch }, typeOf(ifBranch))
-    return [typedNode, env]
+  switch (node.type) {
+    case 'Program':
+      return visitProgram(node, env, nonGeneric)
+    case 'Def':
+      return visitDef(node, env, nonGeneric)
+    case 'Name':
+      return visitName(node, env, nonGeneric)
+    case 'Numeral':
+      return visitNumeral(node, env)
+    case 'Bool':
+      return visitBool(node, env)
+    case 'Str':
+      return visitStr(node, env)
+    case 'Call':
+      return visitCall(node, env, nonGeneric)
+    case 'Array':
+      return visitArray(node, env, nonGeneric)
+    case 'DestructuredArray':
+      return visitDestructuredArray(node, env, nonGeneric)
+    case 'Fn':
+      return visitFn(node, env, nonGeneric)
+    case 'If':
+      return visitIf(node, env, nonGeneric)
+    default:
+      throw new Error(`Uncrecognised AST node type: ${node.type}`)
   }
 }
 
-function typed<T extends AstNode> (node: T, type: Type): TypedNode {
-  return Object.assign({}, node, { exprType: type })
+function visitProgram (node: AstProgramNode, env, nonGeneric): TypeCheckResult<TypedProgramNode> {
+  const [expressions, finalEnv] = visitAll(node.expressions, env, nonGeneric)
+  const programType = typeOf(last(expressions))
+
+  const typedNode = { ...node, expressions, exprType: programType }
+  return [typedNode, finalEnv]
 }
 
-function typeOf (node) {
+function visitDef (node: AstDefNode, env, nonGeneric): TypeCheckResult<TypedDefNode> {
+  if (env.hasOwnProperty(node.name)) {
+    throw new PeachError(`${node.name} has already been defined`)
+  }
+
+  // allow for recursive binding by binding ahead of evaluating the child
+  // analogous to Lisp's letrec, but in the enclosing scope.
+  // TODO immutable env
+  const t = new TypeVariable()
+  env[node.name] = { ...node, exprType: t }
+
+  // if we are defining a function, mark the new identifier as
+  //  non-generic inside the evaluation of the body.
+  const innerNonGeneric = (node.value.type === 'Fn')
+    ? new Set([...nonGeneric, t])
+    : nonGeneric
+
+  const [value] = visit(node.value, env, innerNonGeneric)
+  unify(typeOf(value), t)
+
+  const typedNode = { ...node, value, exprType: t }
+  return [typedNode, env]
+}
+
+function visitName (node: AstNameNode, env, nonGeneric): TypeCheckResult<TypedNameNode> {
+  if (!(node.name in env)) {
+    throw new PeachError(`${node.name} is not defined`)
+  }
+
+  const envType = typeOf(env[node.name])
+  const freshType = fresh(envType, nonGeneric)
+
+  const typedNode = { ...node, exprType: freshType }
+  return [typedNode, env]
+}
+
+function visitNumeral (node: AstNumeralNode, env): TypeCheckResult<TypedNumeralNode> {
+  return [{...node, exprType: NumberType }, env]
+}
+
+function visitBool (node: AstBooleanNode, env): TypeCheckResult<TypedBooleanNode> {
+  return [{ ...node, exprType: BooleanType }, env]
+}
+
+function visitStr (node: AstStringNode, env): TypeCheckResult<TypedStringNode> {
+  return [{ ...node, exprType: StringType }, env]
+}
+
+function visitCall (node: AstCallNode, env, nonGeneric): TypeCheckResult<TypedCallNode> {
+  const [fn] = visit(node.fn, env, nonGeneric)
+  const args: TypedNode[] = node.args.map((arg) => visit(arg, env, nonGeneric)[0])
+
+  const returnType = new TypeVariable()
+  const callFunctionType: Type = makeFunctionType(typesOf(args), returnType)
+
+  unify(callFunctionType, typeOf(fn))
+
+  const typedNode = { ...node, fn: fn as TypedFunctionNode, args, exprType: returnType }
+  return [typedNode, env]
+}
+
+function visitArray (node: AstArrayNode, env, nonGeneric): TypeCheckResult<TypedArrayNode> {
+  let itemType
+  let typedValues
+
+  if (node.values.length > 0) {
+    typedValues = node.values.map((value) => visit(value, env, nonGeneric)[0])
+    const types = typedValues.map(value => value.exprType)
+
+    // arrays are homogenous: all items must have the same type
+    unifyAll(types)
+    itemType = types[0]
+  } else {
+    itemType = new TypeVariable()
+    typedValues = []
+  }
+
+  const arrayType = new ArrayType(itemType)
+  const typedNode = { ...node, values: typedValues, exprType: arrayType }
+
+  return [typedNode, env]
+}
+
+function visitDestructuredArray (node: AstDestructuredArrayNode, env, nonGeneric): TypeCheckResult<TypedDestructuredArrayNode> {
+  const { head, tail } = node
+
+  const boundHeadType = new TypeVariable()
+  const boundTailType = new ArrayType(new TypeVariable())
+
+  // TODO immutable env
+  if (head.type === 'Name') {
+    const typedHead: TypedNameNode = { ...head, exprType: boundHeadType }
+    env[head.name] = typedHead
+    nonGeneric.add(boundHeadType)
+  }
+
+  if (tail.type === 'Name') {
+    const typedTail: TypedNameNode = { ...tail, exprType: boundTailType }
+    env[tail.name] = typedTail
+    nonGeneric.add(boundTailType)
+  }
+
+  const [typedHead] = visit(head, env, nonGeneric)
+  const [typedTail] = visit(tail, env, nonGeneric)
+
+  const headType = typeOf(typedHead)
+  const tailType = typeOf(typedTail)
+
+  // the tail must be a array of the head type
+  // the usage types of head and tail must match the declared types
+  unify(boundHeadType, boundTailType.getType())
+  unify(headType, boundHeadType)
+  unify(tailType, boundTailType)
+
+  const typedNode = { ...node, head: typedHead, tail: typedTail, exprType: tailType }
+  return [typedNode, env]
+}
+
+function visitFn (node: AstFunctionNode, parentEnv, outerNonGeneric): TypeCheckResult<TypedFunctionNode> {
+  // TODO clauses must be exhaustive - functions must accept any input of the right types
+  const clauses: TypedFunctionClauseNode[] = node.clauses.map((clauseNode) => {
+    const nonGeneric = new Set([...outerNonGeneric])
+    const env = create(parentEnv)
+
+    // get the array of arg types
+    const pattern: TypedNode[] = clauseNode.pattern.map(argNode => {
+      // If this is a `Name` arg, define it in the function's arguments environment.
+      // if it's a destructured array we need to recursively define any named children,
+      // so visiting the node will define its names.
+      if (argNode.type === 'Name') {
+        const argType = new TypeVariable()
+        const typedArgNode: TypedNameNode = { ...argNode, exprType: argType }
+
+        env[argNode.name] = typedArgNode
+        nonGeneric.add(argType)
+      }
+
+      const [typedArgNode] = visit(argNode, env, nonGeneric)
+      return typedArgNode
+    })
+
+    const body = clauseNode.body.map(bodyNode => visit(bodyNode, env, nonGeneric)[0])
+    const lastBodyNode = last(body)
+    const returnType = prune(typeOf(lastBodyNode))
+
+    const patternTypes = pattern.map(typeOf)
+
+    const clauseType: Type = makeFunctionType(patternTypes, returnType)
+    return { ...clauseNode, pattern, body, exprType: clauseType }
+  })
+
+  // all clauses must have tbe same type
+  unifyAll(typesOf(clauses))
+
+  const typedNode = { ...node, clauses, exprType: typeOf(clauses[0])}
+  return [typedNode, parentEnv]
+}
+
+function visitIf (node: AstIfNode, env, nonGeneric): TypeCheckResult<TypedIfNode> {
+  const [condition] = visit(node.condition, env, nonGeneric)
+  const [ifBranch] = visit(node.ifBranch, env, nonGeneric)
+  const [elseBranch] = visit(node.elseBranch, env, nonGeneric)
+
+  unify(typeOf(condition), BooleanType)
+  unify(typeOf(ifBranch), typeOf(elseBranch))
+
+  const typedNode = { ...node, condition, ifBranch, elseBranch, exprType: typeOf(ifBranch) }
+  return [typedNode, env]
+}
+
+function typeOf (node: TypedNode): Type {
   return node.exprType
 }
 
@@ -287,7 +316,7 @@ function unifyAll (typeList) {
 
 // makes type1 and exprType the same, or throws
 // if one side is a variable, set a's instance to be b (variable or operator)
-function unify (type1, exprType) {
+function unify (type1: Type, exprType: Type): void {
   const a = prune(type1)
   const b = prune(exprType)
 
@@ -316,7 +345,7 @@ function unify (type1, exprType) {
 // for a type variable, that's the most deeply nested `instance`.
 // for a type operator it's t itself.
 // Always returns a TypeOperator or an unbound TypeVariable.
-function prune (t) {
+function prune (t: Type): Type {
   if (t instanceof TypeVariable) {
     if (t.instance != null) {
       t.instance = prune(t.instance)

--- a/src/util.ts
+++ b/src/util.ts
@@ -11,12 +11,12 @@ export function create (proto, properties = null) {
   return Object.assign(Object.create(proto), properties)
 }
 
-export function restAndLast (arr) {
+export function restAndLast<T> (arr: T[]): [T[], T] {
   const _last = last(arr)
   const rest = arr.slice(0, -1)
   return [rest, _last]
 }
 
-export function last (arr) {
+export function last<T> (arr: T[]): T {
   return arr[arr.length - 1]
 }


### PR DESCRIPTION
[Useful article on tagged unions](https://blog.mariusschulz.com/2016/11/03/typescript-2-0-tagged-union-types)

This gives us static typing for all tree visitors. Uncovered a few bugs waiting to happen ⭐️ 

* [x] type checker
* [x] interpreter 