### PR TITLE
Refactor: AST nodes have a kind. Expressions have a type.

### DIFF
--- a/src/__tests__/__snapshots__/parser-tests.ts.snap
+++ b/src/__tests__/__snapshots__/parser-tests.ts.snap
@@ -8,29 +8,29 @@ Object {
         Object {
           "body": Array [
             Object {
-              "type": "Numeral",
+              "kind": "Numeral",
               "value": 1,
             },
           ],
           "pattern": Array [
             Object {
               "head": Object {
-                "type": "Bool",
+                "kind": "Bool",
                 "value": true,
               },
+              "kind": "DestructuredArray",
               "tail": Object {
+                "kind": "Name",
                 "name": "tail",
-                "type": "Name",
               },
-              "type": "DestructuredArray",
             },
           ],
         },
       ],
-      "type": "Fn",
+      "kind": "Fn",
     },
   ],
-  "type": "Program",
+  "kind": "Program",
 }
 `;
 
@@ -42,22 +42,22 @@ Object {
         Object {
           "body": Array [
             Object {
-              "type": "Numeral",
+              "kind": "Numeral",
               "value": 1,
             },
           ],
           "pattern": Array [
             Object {
-              "type": "Bool",
+              "kind": "Bool",
               "value": true,
             },
           ],
         },
       ],
-      "type": "Fn",
+      "kind": "Fn",
     },
   ],
-  "type": "Program",
+  "kind": "Program",
 }
 `;
 
@@ -65,20 +65,20 @@ exports[`fibonacci.peach 1`] = `
 Object {
   "expressions": Array [
     Object {
+      "kind": "Def",
       "name": "fib",
-      "type": "Def",
       "value": Object {
         "clauses": Array [
           Object {
             "body": Array [
               Object {
-                "type": "Numeral",
+                "kind": "Numeral",
                 "value": 1,
               },
             ],
             "pattern": Array [
               Object {
-                "type": "Numeral",
+                "kind": "Numeral",
                 "value": 0,
               },
             ],
@@ -86,13 +86,13 @@ Object {
           Object {
             "body": Array [
               Object {
-                "type": "Numeral",
+                "kind": "Numeral",
                 "value": 1,
               },
             ],
             "pattern": Array [
               Object {
-                "type": "Numeral",
+                "kind": "Numeral",
                 "value": 1,
               },
             ],
@@ -106,136 +106,136 @@ Object {
                       Object {
                         "args": Array [
                           Object {
+                            "kind": "Name",
                             "name": "x",
-                            "type": "Name",
                           },
                           Object {
-                            "type": "Numeral",
+                            "kind": "Numeral",
                             "value": 1,
                           },
                         ],
                         "fn": Object {
+                          "kind": "Name",
                           "name": "-",
-                          "type": "Name",
                         },
-                        "type": "Call",
+                        "kind": "Call",
                       },
                     ],
                     "fn": Object {
+                      "kind": "Name",
                       "name": "fib",
-                      "type": "Name",
                     },
-                    "type": "Call",
+                    "kind": "Call",
                   },
                   Object {
                     "args": Array [
                       Object {
                         "args": Array [
                           Object {
+                            "kind": "Name",
                             "name": "x",
-                            "type": "Name",
                           },
                           Object {
-                            "type": "Numeral",
+                            "kind": "Numeral",
                             "value": 2,
                           },
                         ],
                         "fn": Object {
+                          "kind": "Name",
                           "name": "-",
-                          "type": "Name",
                         },
-                        "type": "Call",
+                        "kind": "Call",
                       },
                     ],
                     "fn": Object {
+                      "kind": "Name",
                       "name": "fib",
-                      "type": "Name",
                     },
-                    "type": "Call",
+                    "kind": "Call",
                   },
                 ],
                 "fn": Object {
+                  "kind": "Name",
                   "name": "+",
-                  "type": "Name",
                 },
-                "type": "Call",
+                "kind": "Call",
               },
             ],
             "pattern": Array [
               Object {
+                "kind": "Name",
                 "name": "x",
-                "type": "Name",
               },
             ],
           },
         ],
-        "type": "Fn",
+        "kind": "Fn",
       },
     },
     Object {
       "args": Array [
         Object {
+          "kind": "Name",
           "name": "fib",
-          "type": "Name",
         },
         Object {
-          "type": "Array",
+          "kind": "Array",
           "values": Array [
             Object {
-              "type": "Numeral",
+              "kind": "Numeral",
               "value": 0,
             },
             Object {
-              "type": "Numeral",
+              "kind": "Numeral",
               "value": 1,
             },
             Object {
-              "type": "Numeral",
+              "kind": "Numeral",
               "value": 2,
             },
             Object {
-              "type": "Numeral",
+              "kind": "Numeral",
               "value": 3,
             },
             Object {
-              "type": "Numeral",
+              "kind": "Numeral",
               "value": 4,
             },
             Object {
-              "type": "Numeral",
+              "kind": "Numeral",
               "value": 5,
             },
             Object {
-              "type": "Numeral",
+              "kind": "Numeral",
               "value": 6,
             },
             Object {
-              "type": "Numeral",
+              "kind": "Numeral",
               "value": 7,
             },
             Object {
-              "type": "Numeral",
+              "kind": "Numeral",
               "value": 8,
             },
             Object {
-              "type": "Numeral",
+              "kind": "Numeral",
               "value": 9,
             },
             Object {
-              "type": "Numeral",
+              "kind": "Numeral",
               "value": 10,
             },
           ],
         },
       ],
       "fn": Object {
+        "kind": "Name",
         "name": "map",
-        "type": "Name",
       },
-      "type": "Call",
+      "kind": "Call",
     },
   ],
-  "type": "Program",
+  "kind": "Program",
 }
 `;
 
@@ -243,47 +243,47 @@ exports[`str.peach 1`] = `
 Object {
   "expressions": Array [
     Object {
-      "type": "Array",
+      "kind": "Array",
       "values": Array [
         Object {
-          "type": "Str",
+          "kind": "Str",
           "value": "str.peach before escape\\\\\`and after!",
         },
         Object {
-          "type": "Str",
+          "kind": "Str",
           "value": "hey 🌟",
         },
         Object {
-          "type": "Str",
+          "kind": "Str",
           "value": "multi
       line
   string",
         },
         Object {
-          "type": "Str",
+          "kind": "Str",
           "value": "such\\\\\\\\\\\\\\\\\\\\\`escape",
         },
         Object {
-          "type": "Str",
+          "kind": "Str",
           "value": "with	tab",
         },
         Object {
-          "type": "Str",
+          "kind": "Str",
           "value": "new
 line",
         },
         Object {
-          "type": "Str",
+          "kind": "Str",
           "value": "back\\\\slash",
         },
         Object {
-          "type": "Str",
+          "kind": "Str",
           "value": "back\\\\\\\\to\\\\back",
         },
       ],
     },
   ],
-  "type": "Program",
+  "kind": "Program",
 }
 `;
 
@@ -291,24 +291,24 @@ exports[`tail-recursion.peach 1`] = `
 Object {
   "expressions": Array [
     Object {
+      "kind": "Def",
       "name": "factorial",
-      "type": "Def",
       "value": Object {
         "clauses": Array [
           Object {
             "body": Array [
               Object {
+                "kind": "Name",
                 "name": "n",
-                "type": "Name",
               },
             ],
             "pattern": Array [
               Object {
+                "kind": "Name",
                 "name": "n",
-                "type": "Name",
               },
               Object {
-                "type": "Numeral",
+                "kind": "Numeral",
                 "value": 1,
               },
             ],
@@ -320,63 +320,63 @@ Object {
                   Object {
                     "args": Array [
                       Object {
+                        "kind": "Name",
                         "name": "n",
-                        "type": "Name",
                       },
                       Object {
+                        "kind": "Name",
                         "name": "x",
-                        "type": "Name",
                       },
                     ],
                     "fn": Object {
+                      "kind": "Name",
                       "name": "*",
-                      "type": "Name",
                     },
-                    "type": "Call",
+                    "kind": "Call",
                   },
                   Object {
                     "args": Array [
                       Object {
+                        "kind": "Name",
                         "name": "x",
-                        "type": "Name",
                       },
                       Object {
-                        "type": "Numeral",
+                        "kind": "Numeral",
                         "value": 1,
                       },
                     ],
                     "fn": Object {
+                      "kind": "Name",
                       "name": "-",
-                      "type": "Name",
                     },
-                    "type": "Call",
+                    "kind": "Call",
                   },
                 ],
                 "fn": Object {
+                  "kind": "Name",
                   "name": "factorial",
-                  "type": "Name",
                 },
-                "type": "Call",
+                "kind": "Call",
               },
             ],
             "pattern": Array [
               Object {
+                "kind": "Name",
                 "name": "n",
-                "type": "Name",
               },
               Object {
+                "kind": "Name",
                 "name": "x",
-                "type": "Name",
               },
             ],
           },
         ],
-        "type": "Fn",
+        "kind": "Fn",
       },
     },
     Object {
+      "kind": "Def",
       "name": "f",
-      "type": "Def",
       "value": Object {
         "clauses": Array [
           Object {
@@ -384,46 +384,46 @@ Object {
               Object {
                 "args": Array [
                   Object {
-                    "type": "Numeral",
+                    "kind": "Numeral",
                     "value": 1,
                   },
                   Object {
+                    "kind": "Name",
                     "name": "n",
-                    "type": "Name",
                   },
                 ],
                 "fn": Object {
+                  "kind": "Name",
                   "name": "factorial",
-                  "type": "Name",
                 },
-                "type": "Call",
+                "kind": "Call",
               },
             ],
             "pattern": Array [
               Object {
+                "kind": "Name",
                 "name": "n",
-                "type": "Name",
               },
             ],
           },
         ],
-        "type": "Fn",
+        "kind": "Fn",
       },
     },
     Object {
       "args": Array [
         Object {
-          "type": "Numeral",
+          "kind": "Numeral",
           "value": 32768,
         },
       ],
       "fn": Object {
+        "kind": "Name",
         "name": "f",
-        "type": "Name",
       },
-      "type": "Call",
+      "kind": "Call",
     },
   ],
-  "type": "Program",
+  "kind": "Program",
 }
 `;

--- a/src/__tests__/type-checker-tests.ts
+++ b/src/__tests__/type-checker-tests.ts
@@ -19,7 +19,7 @@ function testTypeCheck (source: string, env = getTypeEnv(getRootEnv())) {
   test(source, () => {
     const parsed = parse(source)
     const [lastNode] = typeCheck(parsed, env)
-    const type = lastNode.exprType.toString()
+    const type = lastNode.type.toString()
     expect(type).toMatchSnapshot()
   })
 };
@@ -35,7 +35,7 @@ function testFixture (fixtureName: string, env = getTypeEnv(getRootEnv())) {
   test(fixtureName, () => {
     const parsed = parse(fixture(fixtureName))
     const [lastNode] = typeCheck(parsed, env)
-    const type = lastNode.exprType.toString()
+    const type = lastNode.type.toString()
     expect(type).toMatchSnapshot()
   })
 };
@@ -85,12 +85,12 @@ testFails(`if (1) 1 else 2`)
 // http://smallshire.org.uk/sufficientlysmall/2010/04/11/a-hindley-milner-type-inference-implementation-in-python/
 // (adapted because Peach doesn't have `let` yet; use `def` and test in the enclosing environment)
 
-// the peach type checker works over nodes with an `exprType` property.
+// the peach type checker works over nodes with an `type` property.
 // helper for creating nodes for synthetic type tests
 function typed (type: Type): TypedNode {
   return {
-    exprType: type,
-    type: 'Str',
+    type: type,
+    kind: 'Str',
     value: 'dummy'
   }
 }

--- a/src/__tests__/unify-tests.ts
+++ b/src/__tests__/unify-tests.ts
@@ -5,7 +5,7 @@ import { AstNode, AstStringNode, AstNumeralNode, AstNameNode } from '../node-typ
 
 describe('unify', () => {
   it('can unify one matching value', () => {
-    const patterns: AstStringNode[] = [{ type: 'Str', value: 'hai' }]
+    const patterns: AstStringNode[] = [{ kind: 'Str', value: 'hai' }]
     const values = ['hai']
     expect(unify(patterns, values)).toEqual({
       didMatch: true,
@@ -14,7 +14,7 @@ describe('unify', () => {
   })
 
   it('can unify several matching values', () => {
-    const patterns: AstNumeralNode[] = [{ type: 'Numeral', value: 1 }, { type: 'Numeral', value: 2 }]
+    const patterns: AstNumeralNode[] = [{ kind: 'Numeral', value: 1 }, { kind: 'Numeral', value: 2 }]
     const values = [1, 2]
     expect(unify(patterns, values)).toEqual({
       didMatch: true,
@@ -24,25 +24,25 @@ describe('unify', () => {
 
   // TODO this test is better handled by a type system
   it('cannot unify a loosely equal value', () => {
-    const patterns: AstNumeralNode[] = [{ type: 'Numeral', value: 0 }]
+    const patterns: AstNumeralNode[] = [{ kind: 'Numeral', value: 0 }]
     const values = [false]
     expect(unify(patterns, values)).toEqual({ didMatch: false })
   })
 
   it('cannot unify when the number of patterns and values differs', () => {
-    const patterns: AstNumeralNode[] = [{ type: 'Numeral', value: 1 }, { type: 'Numeral', value: 2 }]
+    const patterns: AstNumeralNode[] = [{ kind: 'Numeral', value: 1 }, { kind: 'Numeral', value: 2 }]
     const values = [1]
     expect(unify(patterns, values)).toEqual({ didMatch: false })
   })
 
   it('cannot unify when some but not all patterns match', () => {
-    const patterns: AstNumeralNode[] = [{ type: 'Numeral', value: 1 }, { type: 'Numeral', value: 2 }]
+    const patterns: AstNumeralNode[] = [{ kind: 'Numeral', value: 1 }, { kind: 'Numeral', value: 2 }]
     const values = [1, 3]
     expect(unify(patterns, values)).toEqual({ didMatch: false })
   })
 
   it('can unify a variable', () => {
-    const patterns: AstNameNode[] = [{ type: 'Name', name: 'x' }]
+    const patterns: AstNameNode[] = [{ kind: 'Name', name: 'x' }]
     const values = [1]
     expect(unify(patterns, values)).toEqual({
       didMatch: true,
@@ -51,7 +51,7 @@ describe('unify', () => {
   })
 
   it('can unify mixed variables and values', () => {
-    const patterns: AstNode[] = [{ type: 'Name', name: 'x' }, { type: 'Numeral', value: 2 }]
+    const patterns: AstNode[] = [{ kind: 'Name', name: 'x' }, { kind: 'Numeral', value: 2 }]
     const values = [1, 2]
     expect(unify(patterns, values)).toEqual({
       didMatch: true,

--- a/src/env.ts
+++ b/src/env.ts
@@ -12,7 +12,7 @@ export function getTypeEnv (valueEnv: RuntimeEnv): TypeEnv {
 
   return Object.keys(valueEnv).reduce((env, name) => {
     env[name] = extend(valueEnv[name], {
-      exprType: valueEnv[name].exprType
+      type: valueEnv[name].type
     })
     return env
   }, initialState)

--- a/src/function.ts
+++ b/src/function.ts
@@ -44,7 +44,7 @@ export function makeFunction (functionNode: TypedFunctionNode, parentEnv: Runtim
         //  check if it's a tail call. If so return a thunk so we can use the trampoline
         //  pattern to avoid call stack overflow. As above - this test needs refining
         // to include any terminal expression in a function.
-        if (lastNode.type === 'Call') {
+        if (lastNode.kind === 'Call') {
           const resolvedFunction = visit(lastNode.fn, env)[0]
           if (resolvedFunction === pFunction) {
             // evaluate the re-entrant args without recursing to `visit(lastNode)`
@@ -79,13 +79,13 @@ export function makeFunction (functionNode: TypedFunctionNode, parentEnv: Runtim
 }
 
 export function makeNativeFunction (name: string, jsFunction: Function, argTypes: Type[], returnType: Type) {
-  const exprType = makeFunctionType(argTypes, returnType)
+  const type = makeFunctionType(argTypes, returnType)
 
   return {
     name,
     arity: argTypes.length,
     call: jsFunction,
-    exprType,
+    type,
     toString: () => `built-in ${name}`
   }
 }

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -29,13 +29,13 @@ function visitSerial (nodes: TypedNode[], rootEnv: RuntimeEnv): InterpreterResul
 
 function visitUnknown (node: TypedNode, env: RuntimeEnv): InterpreterResult {
   console.log(JSON.stringify(node, null, 2))
-  throw new PeachError(`unknown node type: ${node.type}`)
+  throw new PeachError(`unknown node type: ${node.kind}`)
 }
 
 function visit (node: TypedNode, env: RuntimeEnv): InterpreterResult {
   // console.log(`TRACE interpreter: ${node.type}\n${JSON.stringify(node)}`)
 
-  switch (node.type) {
+  switch (node.kind) {
     case 'Program':
       return visitProgram(node, env)
     case 'Def':
@@ -57,7 +57,7 @@ function visit (node: TypedNode, env: RuntimeEnv): InterpreterResult {
     case 'If':
       return visitIf(node, env)
     default:
-      throw new Error(`Uncrecognised AST node type: ${node.type}`)
+      throw new Error(`Uncrecognised AST node kind: ${node.kind}`)
   }
 }
 

--- a/src/node-types.ts
+++ b/src/node-types.ts
@@ -9,7 +9,7 @@ export type TypedAst = TypedProgramNode
 
 // Ast*: parser output. Typed raw AST nodes.
 export interface AstBaseNode {
-  type: string
+  kind: string
 }
 
 export type AstNode
@@ -44,11 +44,11 @@ export type TypedNode
   | TypedDefPreValueNode
 
 export interface Typed {
-  exprType: Type
+  type: Type
 }
 
 export interface AstProgramNode {
-  type: 'Program',
+  kind: 'Program',
   expressions: AstNode[]
 }
 
@@ -57,7 +57,7 @@ export interface TypedProgramNode extends AstProgramNode, Typed {
 }
 
 export interface AstDefNode {
-  type: 'Def',
+  kind: 'Def',
   name: string,
   value: AstNode
 }
@@ -67,35 +67,35 @@ export interface TypedDefNode extends AstDefNode, Typed {
 }
 
 export interface AstNameNode {
-  type: 'Name',
+  kind: 'Name',
   name: string
 }
 
 export interface TypedNameNode extends AstNameNode, Typed { }
 
 export interface AstNumeralNode {
-  type: 'Numeral',
+  kind: 'Numeral',
   value: number
 }
 
 export interface TypedNumeralNode extends AstNumeralNode, Typed { }
 
 export interface AstBooleanNode {
-  type: 'Bool',
+  kind: 'Bool',
   value: boolean
 }
 
 export interface TypedBooleanNode extends AstBooleanNode, Typed { }
 
 export interface AstStringNode {
-  type: 'Str',
+  kind: 'Str',
   value: string
 }
 
 export interface TypedStringNode extends AstStringNode, Typed { }
 
 export interface AstCallNode {
-  type: 'Call',
+  kind: 'Call',
   fn: AstNode,
   args: AstNode[]
 }
@@ -106,7 +106,7 @@ export interface TypedCallNode extends AstCallNode, Typed {
 }
 
 export interface AstArrayNode {
-  type: 'Array',
+  kind: 'Array',
   values: AstNode[]
 }
 
@@ -115,7 +115,7 @@ export interface TypedArrayNode extends AstArrayNode, Typed {
 }
 
 export interface AstDestructuredArrayNode {
-  type: 'DestructuredArray',
+  kind: 'DestructuredArray',
   head: AstNode,
   tail: AstNode
 }
@@ -126,7 +126,7 @@ export interface TypedDestructuredArrayNode extends AstDestructuredArrayNode, Ty
 }
 
 export interface AstFunctionNode {
-  type: 'Fn',
+  kind: 'Fn',
   clauses: AstFunctionClauseNode[]
 }
 
@@ -135,7 +135,7 @@ export interface TypedFunctionNode extends AstFunctionNode, Typed {
 }
 
 export interface AstFunctionClauseNode {
-  type: 'FunctionClause',
+  kind: 'FunctionClause',
   pattern: AstNode[],
   body: AstNode[]
 }
@@ -146,7 +146,7 @@ export interface TypedFunctionClauseNode extends AstFunctionClauseNode, Typed {
 }
 
 export interface AstIfNode {
-  type: 'If',
+  kind: 'If',
   condition: AstNode,
   ifBranch: AstNode,
   elseBranch: AstNode
@@ -167,7 +167,7 @@ export interface TypedIfNode extends AstIfNode, Typed {
 // We only need the Typed variant, but the Ast*Node is required to maintain
 // the AstNode -> TypedNode mapping.
 export interface AstDefPreValueNode {
-  type: 'DefPreValue'
+  kind: 'DefPreValue'
 }
 
 export interface TypedDefPreValueNode extends Typed, AstDefPreValueNode { }
@@ -182,7 +182,7 @@ export type TypedLiteralNode = TypedStringNode | TypedBooleanNode | TypedNumeral
 // Guard functions
 //
 export function isAstLiteralNode (node: AstNode): node is AstLiteralNode {
-  return ['Bool', 'Str', 'Numeral'].includes(node.type)
+  return ['Bool', 'Str', 'Numeral'].includes(node.kind)
 }
 
 //
@@ -192,7 +192,7 @@ export function isAstLiteralNode (node: AstNode): node is AstLiteralNode {
 export type Value = any
 
 export interface ValueNode {
-  exprType: Type,
+  type: Type,
   node: AstNode,
   value: Value
 }

--- a/src/peach.pegjs
+++ b/src/peach.pegjs
@@ -4,7 +4,7 @@ start
 // a program is a list of newline-delimted expressions
 program = head:expression tail:(eol e:expression { return e })* {
   return {
-    type: "Program",
+    kind: "Program",
     expressions: [head, ...tail]
   }
 }
@@ -28,7 +28,7 @@ expression_list =
 
 def = name_expr:name __ "=" __ value:expression {
   return {
-    type: "Def",
+    kind: "Def",
     name: name_expr.name,
     value
   }
@@ -36,7 +36,7 @@ def = name_expr:name __ "=" __ value:expression {
 
 fn = clauses:clause_list_optional_parens {
   return {
-    type: "Fn",
+    kind: "Fn",
     clauses
   }
 }
@@ -76,7 +76,7 @@ destructure_tail = name / destructured_vector
 
 destructured_vector = ls head:destructure_head _ "|" tail:destructure_tail _ rs {
   return {
-    type: "DestructuredArray",
+    kind: "DestructuredArray",
     head,
     tail
   }
@@ -84,7 +84,7 @@ destructured_vector = ls head:destructure_head _ "|" tail:destructure_tail _ rs 
 
 if = "if" _ lp condition:expression rp __ ifBranch:expression __ "else" __ elseBranch:expression {
   return {
-    type: "If",
+    kind: "If",
     condition,
     ifBranch,
     elseBranch
@@ -94,7 +94,7 @@ if = "if" _ lp condition:expression rp __ ifBranch:expression __ "else" __ elseB
 
 name = value:name_value {
   return {
-    type: "Name",
+    kind: "Name",
     name: value
   }
 }
@@ -109,14 +109,14 @@ literal = numeral / boolean / string
 
 numeral = digits:[0-9]+ {
   return {
-    type: "Numeral",
+    kind: "Numeral",
     value: parseInt(digits.join(""), 10)
   };
 }
 
 boolean = value:boolean_value {
   return {
-    type: "Bool",
+    kind: "Bool",
     value
   }
 }
@@ -127,7 +127,7 @@ boolean_value
 
 string = "`" tokens:string_token* "`" {
   return {
-    type: "Str",
+    kind: "Str",
     value: tokens.join("")
   }
 }
@@ -152,7 +152,7 @@ escape_sequence
 call = lp values:expression_list rp {
   const [fn, ...args] = values
   return {
-    type: "Call",
+    kind: "Call",
     fn,
     args
   }
@@ -162,14 +162,14 @@ vector = empty_vector / non_empty_vector
 
 empty_vector = ls rs {
   return {
-    type: "Array",
+    kind: "Array",
     values: []
   }
 }
 
 non_empty_vector = ls values:expression_list rs {
   return {
-    type: "Array",
+    kind: "Array",
     values
   }
 }

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -31,7 +31,7 @@ export default function startRepl (options: any, onExit: (status: Number) => voi
       lastEnv = nextEnv
       lastTypeEnv = nextTypeEnv
 
-      const typedResult = `${result}: ${typed.exprType}`
+      const typedResult = `${result}: ${typed.type}`
       return callback(null, typedResult)
     } catch (e) {
       if (isRecoverableError(e)) {

--- a/src/unify.ts
+++ b/src/unify.ts
@@ -46,17 +46,17 @@ function unifyOne (pattern: AstNode, value: Value): UnifyResult {
     return didMatch({})
   }
 
-  if (pattern.type === 'Name') {
+  if (pattern.kind === 'Name') {
     // the pattern matched; return a new binding
     return didMatch({ [pattern.name]: value })
   }
 
   // TODO generic value equality
-  if (pattern.type === 'Array' && isEqual(pattern.values, value)) {
+  if (pattern.kind === 'Array' && isEqual(pattern.values, value)) {
     return didMatch({})
   }
 
-  if (pattern.type === 'DestructuredArray') {
+  if (pattern.kind === 'DestructuredArray') {
     return destructure(pattern, value)
   }
 


### PR DESCRIPTION
Rename AST and Typed node fields for consistency and clarity.

* `kind` is a string tag that identifies AST node types
* `type` is a Peach type system type.
* `exprType` is no more!