### PR TITLE
Grammar: rename some AST node kinds

### DIFF
--- a/src/__tests__/__snapshots__/parser-tests.ts.snap
+++ b/src/__tests__/__snapshots__/parser-tests.ts.snap
@@ -8,26 +8,26 @@ Object {
         Object {
           "body": Array [
             Object {
-              "kind": "Numeral",
+              "kind": "Number",
               "value": 1,
             },
           ],
           "pattern": Array [
             Object {
               "head": Object {
-                "kind": "Bool",
+                "kind": "Boolean",
                 "value": true,
               },
               "kind": "DestructuredArray",
               "tail": Object {
-                "kind": "Name",
+                "kind": "Identifier",
                 "name": "tail",
               },
             },
           ],
         },
       ],
-      "kind": "Fn",
+      "kind": "Function",
     },
   ],
   "kind": "Program",
@@ -42,19 +42,19 @@ Object {
         Object {
           "body": Array [
             Object {
-              "kind": "Numeral",
+              "kind": "Number",
               "value": 1,
             },
           ],
           "pattern": Array [
             Object {
-              "kind": "Bool",
+              "kind": "Boolean",
               "value": true,
             },
           ],
         },
       ],
-      "kind": "Fn",
+      "kind": "Function",
     },
   ],
   "kind": "Program",
@@ -72,13 +72,13 @@ Object {
           Object {
             "body": Array [
               Object {
-                "kind": "Numeral",
+                "kind": "Number",
                 "value": 1,
               },
             ],
             "pattern": Array [
               Object {
-                "kind": "Numeral",
+                "kind": "Number",
                 "value": 0,
               },
             ],
@@ -86,13 +86,13 @@ Object {
           Object {
             "body": Array [
               Object {
-                "kind": "Numeral",
+                "kind": "Number",
                 "value": 1,
               },
             ],
             "pattern": Array [
               Object {
-                "kind": "Numeral",
+                "kind": "Number",
                 "value": 1,
               },
             ],
@@ -106,23 +106,23 @@ Object {
                       Object {
                         "args": Array [
                           Object {
-                            "kind": "Name",
+                            "kind": "Identifier",
                             "name": "x",
                           },
                           Object {
-                            "kind": "Numeral",
+                            "kind": "Number",
                             "value": 1,
                           },
                         ],
                         "fn": Object {
-                          "kind": "Name",
+                          "kind": "Identifier",
                           "name": "-",
                         },
                         "kind": "Call",
                       },
                     ],
                     "fn": Object {
-                      "kind": "Name",
+                      "kind": "Identifier",
                       "name": "fib",
                     },
                     "kind": "Call",
@@ -132,30 +132,30 @@ Object {
                       Object {
                         "args": Array [
                           Object {
-                            "kind": "Name",
+                            "kind": "Identifier",
                             "name": "x",
                           },
                           Object {
-                            "kind": "Numeral",
+                            "kind": "Number",
                             "value": 2,
                           },
                         ],
                         "fn": Object {
-                          "kind": "Name",
+                          "kind": "Identifier",
                           "name": "-",
                         },
                         "kind": "Call",
                       },
                     ],
                     "fn": Object {
-                      "kind": "Name",
+                      "kind": "Identifier",
                       "name": "fib",
                     },
                     "kind": "Call",
                   },
                 ],
                 "fn": Object {
-                  "kind": "Name",
+                  "kind": "Identifier",
                   "name": "+",
                 },
                 "kind": "Call",
@@ -163,73 +163,73 @@ Object {
             ],
             "pattern": Array [
               Object {
-                "kind": "Name",
+                "kind": "Identifier",
                 "name": "x",
               },
             ],
           },
         ],
-        "kind": "Fn",
+        "kind": "Function",
       },
     },
     Object {
       "args": Array [
         Object {
-          "kind": "Name",
+          "kind": "Identifier",
           "name": "fib",
         },
         Object {
           "kind": "Array",
           "values": Array [
             Object {
-              "kind": "Numeral",
+              "kind": "Number",
               "value": 0,
             },
             Object {
-              "kind": "Numeral",
+              "kind": "Number",
               "value": 1,
             },
             Object {
-              "kind": "Numeral",
+              "kind": "Number",
               "value": 2,
             },
             Object {
-              "kind": "Numeral",
+              "kind": "Number",
               "value": 3,
             },
             Object {
-              "kind": "Numeral",
+              "kind": "Number",
               "value": 4,
             },
             Object {
-              "kind": "Numeral",
+              "kind": "Number",
               "value": 5,
             },
             Object {
-              "kind": "Numeral",
+              "kind": "Number",
               "value": 6,
             },
             Object {
-              "kind": "Numeral",
+              "kind": "Number",
               "value": 7,
             },
             Object {
-              "kind": "Numeral",
+              "kind": "Number",
               "value": 8,
             },
             Object {
-              "kind": "Numeral",
+              "kind": "Number",
               "value": 9,
             },
             Object {
-              "kind": "Numeral",
+              "kind": "Number",
               "value": 10,
             },
           ],
         },
       ],
       "fn": Object {
-        "kind": "Name",
+        "kind": "Identifier",
         "name": "map",
       },
       "kind": "Call",
@@ -246,38 +246,38 @@ Object {
       "kind": "Array",
       "values": Array [
         Object {
-          "kind": "Str",
+          "kind": "String",
           "value": "str.peach before escape\\\\\`and after!",
         },
         Object {
-          "kind": "Str",
+          "kind": "String",
           "value": "hey 🌟",
         },
         Object {
-          "kind": "Str",
+          "kind": "String",
           "value": "multi
       line
   string",
         },
         Object {
-          "kind": "Str",
+          "kind": "String",
           "value": "such\\\\\\\\\\\\\\\\\\\\\`escape",
         },
         Object {
-          "kind": "Str",
+          "kind": "String",
           "value": "with	tab",
         },
         Object {
-          "kind": "Str",
+          "kind": "String",
           "value": "new
 line",
         },
         Object {
-          "kind": "Str",
+          "kind": "String",
           "value": "back\\\\slash",
         },
         Object {
-          "kind": "Str",
+          "kind": "String",
           "value": "back\\\\\\\\to\\\\back",
         },
       ],
@@ -298,17 +298,17 @@ Object {
           Object {
             "body": Array [
               Object {
-                "kind": "Name",
+                "kind": "Identifier",
                 "name": "n",
               },
             ],
             "pattern": Array [
               Object {
-                "kind": "Name",
+                "kind": "Identifier",
                 "name": "n",
               },
               Object {
-                "kind": "Numeral",
+                "kind": "Number",
                 "value": 1,
               },
             ],
@@ -320,16 +320,16 @@ Object {
                   Object {
                     "args": Array [
                       Object {
-                        "kind": "Name",
+                        "kind": "Identifier",
                         "name": "n",
                       },
                       Object {
-                        "kind": "Name",
+                        "kind": "Identifier",
                         "name": "x",
                       },
                     ],
                     "fn": Object {
-                      "kind": "Name",
+                      "kind": "Identifier",
                       "name": "*",
                     },
                     "kind": "Call",
@@ -337,23 +337,23 @@ Object {
                   Object {
                     "args": Array [
                       Object {
-                        "kind": "Name",
+                        "kind": "Identifier",
                         "name": "x",
                       },
                       Object {
-                        "kind": "Numeral",
+                        "kind": "Number",
                         "value": 1,
                       },
                     ],
                     "fn": Object {
-                      "kind": "Name",
+                      "kind": "Identifier",
                       "name": "-",
                     },
                     "kind": "Call",
                   },
                 ],
                 "fn": Object {
-                  "kind": "Name",
+                  "kind": "Identifier",
                   "name": "factorial",
                 },
                 "kind": "Call",
@@ -361,17 +361,17 @@ Object {
             ],
             "pattern": Array [
               Object {
-                "kind": "Name",
+                "kind": "Identifier",
                 "name": "n",
               },
               Object {
-                "kind": "Name",
+                "kind": "Identifier",
                 "name": "x",
               },
             ],
           },
         ],
-        "kind": "Fn",
+        "kind": "Function",
       },
     },
     Object {
@@ -384,16 +384,16 @@ Object {
               Object {
                 "args": Array [
                   Object {
-                    "kind": "Numeral",
+                    "kind": "Number",
                     "value": 1,
                   },
                   Object {
-                    "kind": "Name",
+                    "kind": "Identifier",
                     "name": "n",
                   },
                 ],
                 "fn": Object {
-                  "kind": "Name",
+                  "kind": "Identifier",
                   "name": "factorial",
                 },
                 "kind": "Call",
@@ -401,24 +401,24 @@ Object {
             ],
             "pattern": Array [
               Object {
-                "kind": "Name",
+                "kind": "Identifier",
                 "name": "n",
               },
             ],
           },
         ],
-        "kind": "Fn",
+        "kind": "Function",
       },
     },
     Object {
       "args": Array [
         Object {
-          "kind": "Numeral",
+          "kind": "Number",
           "value": 32768,
         },
       ],
       "fn": Object {
-        "kind": "Name",
+        "kind": "Identifier",
         "name": "f",
       },
       "kind": "Call",

--- a/src/__tests__/type-checker-tests.ts
+++ b/src/__tests__/type-checker-tests.ts
@@ -90,7 +90,7 @@ testFails(`if (1) 1 else 2`)
 function typed (type: Type): TypedNode {
   return {
     type: type,
-    kind: 'Str',
+    kind: 'String',
     value: 'dummy'
   }
 }

--- a/src/__tests__/unify-tests.ts
+++ b/src/__tests__/unify-tests.ts
@@ -1,11 +1,11 @@
 /* eslint-env jest */
 import unify from '../unify'
 import { StringType } from '../types'
-import { AstNode, AstStringNode, AstNumeralNode, AstNameNode } from '../node-types'
+import { AstNode, AstStringNode, AstNumberNode, AstIdentifierNode } from '../node-types'
 
 describe('unify', () => {
   it('can unify one matching value', () => {
-    const patterns: AstStringNode[] = [{ kind: 'Str', value: 'hai' }]
+    const patterns: AstStringNode[] = [{ kind: 'String', value: 'hai' }]
     const values = ['hai']
     expect(unify(patterns, values)).toEqual({
       didMatch: true,
@@ -14,7 +14,7 @@ describe('unify', () => {
   })
 
   it('can unify several matching values', () => {
-    const patterns: AstNumeralNode[] = [{ kind: 'Numeral', value: 1 }, { kind: 'Numeral', value: 2 }]
+    const patterns: AstNumberNode[] = [{ kind: 'Number', value: 1 }, { kind: 'Number', value: 2 }]
     const values = [1, 2]
     expect(unify(patterns, values)).toEqual({
       didMatch: true,
@@ -24,25 +24,25 @@ describe('unify', () => {
 
   // TODO this test is better handled by a type system
   it('cannot unify a loosely equal value', () => {
-    const patterns: AstNumeralNode[] = [{ kind: 'Numeral', value: 0 }]
+    const patterns: AstNumberNode[] = [{ kind: 'Number', value: 0 }]
     const values = [false]
     expect(unify(patterns, values)).toEqual({ didMatch: false })
   })
 
   it('cannot unify when the number of patterns and values differs', () => {
-    const patterns: AstNumeralNode[] = [{ kind: 'Numeral', value: 1 }, { kind: 'Numeral', value: 2 }]
+    const patterns: AstNumberNode[] = [{ kind: 'Number', value: 1 }, { kind: 'Number', value: 2 }]
     const values = [1]
     expect(unify(patterns, values)).toEqual({ didMatch: false })
   })
 
   it('cannot unify when some but not all patterns match', () => {
-    const patterns: AstNumeralNode[] = [{ kind: 'Numeral', value: 1 }, { kind: 'Numeral', value: 2 }]
+    const patterns: AstNumberNode[] = [{ kind: 'Number', value: 1 }, { kind: 'Number', value: 2 }]
     const values = [1, 3]
     expect(unify(patterns, values)).toEqual({ didMatch: false })
   })
 
   it('can unify a variable', () => {
-    const patterns: AstNameNode[] = [{ kind: 'Name', name: 'x' }]
+    const patterns: AstIdentifierNode[] = [{ kind: 'Identifier', name: 'x' }]
     const values = [1]
     expect(unify(patterns, values)).toEqual({
       didMatch: true,
@@ -51,7 +51,7 @@ describe('unify', () => {
   })
 
   it('can unify mixed variables and values', () => {
-    const patterns: AstNode[] = [{ kind: 'Name', name: 'x' }, { kind: 'Numeral', value: 2 }]
+    const patterns: AstNode[] = [{ kind: 'Identifier', name: 'x' }, { kind: 'Number', value: 2 }]
     const values = [1, 2]
     expect(unify(patterns, values)).toEqual({
       didMatch: true,

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -4,8 +4,8 @@ import { extend, clone } from './util'
 import PeachError from './errors'
 import { getRootEnv, RuntimeEnv } from './env'
 import {
-  Value, TypedAst, TypedNode, TypedProgramNode, TypedDefNode, TypedNameNode,
-  TypedNumeralNode, TypedBooleanNode, TypedStringNode, TypedCallNode, TypedArrayNode,
+  Value, TypedAst, TypedNode, TypedProgramNode, TypedDefNode, TypedIdentifierNode,
+  TypedNumberNode, TypedBooleanNode, TypedStringNode, TypedCallNode, TypedArrayNode,
   TypedDestructuredArrayNode, TypedFunctionNode, TypedIfNode
 } from './node-types'
 
@@ -40,19 +40,19 @@ function visit (node: TypedNode, env: RuntimeEnv): InterpreterResult {
       return visitProgram(node, env)
     case 'Def':
       return visitDef(node, env)
-    case 'Name':
+    case 'Identifier':
       return visitName(node, env)
-    case 'Numeral':
+    case 'Number':
       return visitNumeral(node, env)
-    case 'Bool':
+    case 'Boolean':
       return visitBool(node, env)
-    case 'Str':
+    case 'String':
       return visitStr(node, env)
     case 'Call':
       return visitCall(node, env)
     case 'Array':
       return visitArray(node, env)
-    case 'Fn':
+    case 'Function':
       return visitFn(node, env)
     case 'If':
       return visitIf(node, env)
@@ -82,7 +82,7 @@ function visitDef ({ name, value }: TypedDefNode, env: RuntimeEnv): InterpreterR
   return [result, env]
 }
 
-function visitName ({ name }: TypedNameNode, env: RuntimeEnv): InterpreterResult {
+function visitName ({ name }: TypedIdentifierNode, env: RuntimeEnv): InterpreterResult {
   if (!(name in env)) {
     throw new PeachError(`${name} is not defined`)
   }
@@ -90,7 +90,7 @@ function visitName ({ name }: TypedNameNode, env: RuntimeEnv): InterpreterResult
   return [env[name], env]
 }
 
-function visitNumeral ({ value }: TypedNumeralNode, env: RuntimeEnv): InterpreterResult {
+function visitNumeral ({ value }: TypedNumberNode, env: RuntimeEnv): InterpreterResult {
   return [value, env]
 }
 

--- a/src/node-types.ts
+++ b/src/node-types.ts
@@ -15,8 +15,8 @@ export interface AstBaseNode {
 export type AstNode
   = AstProgramNode
   | AstDefNode
-  | AstNameNode
-  | AstNumeralNode
+  | AstIdentifierNode
+  | AstNumberNode
   | AstBooleanNode
   | AstStringNode
   | AstCallNode
@@ -31,8 +31,8 @@ export type AstNode
 export type TypedNode
   = TypedProgramNode
   | TypedDefNode
-  | TypedNameNode
-  | TypedNumeralNode
+  | TypedIdentifierNode
+  | TypedNumberNode
   | TypedBooleanNode
   | TypedStringNode
   | TypedCallNode
@@ -66,29 +66,29 @@ export interface TypedDefNode extends AstDefNode, Typed {
   value: TypedNode
 }
 
-export interface AstNameNode {
-  kind: 'Name',
+export interface AstIdentifierNode {
+  kind: 'Identifier',
   name: string
 }
 
-export interface TypedNameNode extends AstNameNode, Typed { }
+export interface TypedIdentifierNode extends AstIdentifierNode, Typed { }
 
-export interface AstNumeralNode {
-  kind: 'Numeral',
+export interface AstNumberNode {
+  kind: 'Number',
   value: number
 }
 
-export interface TypedNumeralNode extends AstNumeralNode, Typed { }
+export interface TypedNumberNode extends AstNumberNode, Typed { }
 
 export interface AstBooleanNode {
-  kind: 'Bool',
+  kind: 'Boolean',
   value: boolean
 }
 
 export interface TypedBooleanNode extends AstBooleanNode, Typed { }
 
 export interface AstStringNode {
-  kind: 'Str',
+  kind: 'String',
   value: string
 }
 
@@ -126,7 +126,7 @@ export interface TypedDestructuredArrayNode extends AstDestructuredArrayNode, Ty
 }
 
 export interface AstFunctionNode {
-  kind: 'Fn',
+  kind: 'Function',
   clauses: AstFunctionClauseNode[]
 }
 
@@ -175,14 +175,14 @@ export interface TypedDefPreValueNode extends Typed, AstDefPreValueNode { }
 //
 // Nodes with shared traits
 //
-export type AstLiteralNode = AstStringNode | AstBooleanNode | AstNumeralNode
-export type TypedLiteralNode = TypedStringNode | TypedBooleanNode | TypedNumeralNode
+export type AstLiteralNode = AstStringNode | AstBooleanNode | AstNumberNode
+export type TypedLiteralNode = TypedStringNode | TypedBooleanNode | TypedNumberNode
 
 //
 // Guard functions
 //
 export function isAstLiteralNode (node: AstNode): node is AstLiteralNode {
-  return ['Bool', 'Str', 'Numeral'].includes(node.kind)
+  return ['Boolean', 'String', 'Number'].includes(node.kind)
 }
 
 //

--- a/src/peach.pegjs
+++ b/src/peach.pegjs
@@ -11,14 +11,14 @@ program = head:expression tail:(eol e:expression { return e })* {
 
 expression
   = def
-  / fn
+  / function
   / if
-  / numeral
+  / number
   / boolean
   / string
-  / vector
+  / array
   / call
-  / name
+  / identifier
 
 // a list of whitespace-delimited expressions
 expression_list =
@@ -26,17 +26,17 @@ expression_list =
   return [head, ...tail];
 }
 
-def = name_expr:name __ "=" __ value:expression {
+def = identifier_expr:identifier __ "=" __ value:expression {
   return {
     kind: "Def",
-    name: name_expr.name,
+    name: identifier_expr.name,
     value
   }
 }
 
-fn = clauses:clause_list_optional_parens {
+function = clauses:clause_list_optional_parens {
   return {
-    kind: "Fn",
+    kind: "Function",
     clauses
   }
 }
@@ -69,12 +69,12 @@ pattern_term_list = lp head:pattern_term tail:(__ p:pattern_term { return p })* 
 // TODO I guess it makes sense for the syntax to allow any expression here.
 // unify.js can decide at compile time if the passed expression makes sense
 // (most types do, e.g. a function doesn't).
-pattern_term = literal / name / destructured_vector / empty_vector
+pattern_term = literal / identifier / destructured_array / empty_array
 
-destructure_head =  literal / name
-destructure_tail = name / destructured_vector
+destructure_head =  literal / identifier
+destructure_tail = identifier / destructured_array
 
-destructured_vector = ls head:destructure_head _ "|" tail:destructure_tail _ rs {
+destructured_array = ls head:destructure_head _ "|" tail:destructure_tail _ rs {
   return {
     kind: "DestructuredArray",
     head,
@@ -91,32 +91,31 @@ if = "if" _ lp condition:expression rp __ ifBranch:expression __ "else" __ elseB
   }
 }
 
-
-name = value:name_value {
+identifier = name:identifier_name {
   return {
-    kind: "Name",
-    name: value
+    kind: "Identifier",
+    name
   }
 }
 
-name_value
+identifier_name
   = reserved_name
   / first:[a-zA-Z_\$] chars:[a-zA-Z0-9\-_\$]* { return first + chars.join("") }
 
 reserved_name = "!" / "+" / "-" / "*" / "/" / "%" / "&&" / "||" / "==" / "=" / "<=>" / "<=" / "<" / ">=" / ">"
 
-literal = numeral / boolean / string
+literal = number / boolean / string
 
-numeral = digits:[0-9]+ {
+number = digits:[0-9]+ {
   return {
-    kind: "Numeral",
+    kind: "Number",
     value: parseInt(digits.join(""), 10)
   };
 }
 
 boolean = value:boolean_value {
   return {
-    kind: "Bool",
+    kind: "Boolean",
     value
   }
 }
@@ -127,7 +126,7 @@ boolean_value
 
 string = "`" tokens:string_token* "`" {
   return {
-    kind: "Str",
+    kind: "String",
     value: tokens.join("")
   }
 }
@@ -158,22 +157,21 @@ call = lp values:expression_list rp {
   }
 }
 
-vector = empty_vector / non_empty_vector
+array = empty_array / non_empty_array
 
-empty_vector = ls rs {
+empty_array = ls rs {
   return {
     kind: "Array",
     values: []
   }
 }
 
-non_empty_vector = ls values:expression_list rs {
+non_empty_array = ls values:expression_list rs {
   return {
     kind: "Array",
     values
   }
 }
-
 
 lp = "(" _ { return "(" }
 rp = _ ")" { return ")" }

--- a/src/unify.ts
+++ b/src/unify.ts
@@ -46,7 +46,7 @@ function unifyOne (pattern: AstNode, value: Value): UnifyResult {
     return didMatch({})
   }
 
-  if (pattern.kind === 'Name') {
+  if (pattern.kind === 'Identifier') {
     // the pattern matched; return a new binding
     return didMatch({ [pattern.name]: value })
   }


### PR DESCRIPTION
Some of the old names were chosen to avoid clashes with JavaScript
types. That isn't a concern now (because AST kinds are never used as
JavaScript identifiers), so they can be renamed to nicer to less
natural values.