### PR TITLE
language: add basic tuple type

### DIFF
--- a/src/__tests__/__snapshots__/parser-tests.ts.snap
+++ b/src/__tests__/__snapshots__/parser-tests.ts.snap
@@ -369,6 +369,30 @@ Object {
 }
 `;
 
+exports[`get(t(\`a\`), 0) 1`] = `
+Object {
+  "expressions": Array [
+    Object {
+      "kind": "Member",
+      "name": Object {
+        "kind": "Number",
+        "value": 0,
+      },
+      "source": Object {
+        "kind": "Tuple",
+        "values": Array [
+          Object {
+            "kind": "String",
+            "value": "a",
+          },
+        ],
+      },
+    },
+  ],
+  "kind": "Program",
+}
+`;
+
 exports[`str.peach 1`] = `
 Object {
   "expressions": Array [

--- a/src/__tests__/__snapshots__/parser-tests.ts.snap
+++ b/src/__tests__/__snapshots__/parser-tests.ts.snap
@@ -417,6 +417,83 @@ line",
 }
 `;
 
+exports[`t() 1`] = `
+Object {
+  "expressions": Array [
+    Object {
+      "kind": "Tuple",
+      "values": Array [],
+    },
+  ],
+  "kind": "Program",
+}
+`;
+
+exports[`t(\`1\`, (2), (x) => 3) 1`] = `
+Object {
+  "expressions": Array [
+    Object {
+      "kind": "Tuple",
+      "values": Array [
+        Object {
+          "kind": "String",
+          "value": "1",
+        },
+        Object {
+          "args": Array [],
+          "fn": Object {
+            "kind": "Number",
+            "value": 2,
+          },
+          "kind": "Call",
+        },
+        Object {
+          "clauses": Array [
+            Object {
+              "body": Array [
+                Object {
+                  "kind": "Number",
+                  "value": 3,
+                },
+              ],
+              "pattern": Array [
+                Object {
+                  "kind": "Identifier",
+                  "name": "x",
+                },
+              ],
+            },
+          ],
+          "kind": "Function",
+        },
+      ],
+    },
+  ],
+  "kind": "Program",
+}
+`;
+
+exports[`t(1, 2) 1`] = `
+Object {
+  "expressions": Array [
+    Object {
+      "kind": "Tuple",
+      "values": Array [
+        Object {
+          "kind": "Number",
+          "value": 1,
+        },
+        Object {
+          "kind": "Number",
+          "value": 2,
+        },
+      ],
+    },
+  ],
+  "kind": "Program",
+}
+`;
+
 exports[`tail-recursion.peach 1`] = `
 Object {
   "expressions": Array [

--- a/src/__tests__/__snapshots__/type-checker-tests.ts.snap
+++ b/src/__tests__/__snapshots__/type-checker-tests.ts.snap
@@ -139,6 +139,12 @@ exports[`if (true) 1 else 2 1`] = `"Number"`;
 
 exports[`str.peach 1`] = `"Array<String>"`;
 
+exports[`t() 1`] = `"()"`;
+
+exports[`t(1, 2) 1`] = `"(Number, Number)"`;
+
+exports[`t(t(), t(\`hi\`, 1, x => t(x, (+ x, 1)))) 1`] = `"((), (String, Number, Number -> (Number, Number)))"`;
+
 exports[`tail-recursion.peach 1`] = `"Number"`;
 
 exports[`true 1`] = `"Boolean"`;

--- a/src/__tests__/__snapshots__/type-checker-tests.ts.snap
+++ b/src/__tests__/__snapshots__/type-checker-tests.ts.snap
@@ -78,6 +78,16 @@ x => {
 } 1`] = `"Number -> Number"`;
 
 exports[`
+x = 1
+get([1,2], x)
+ 1`] = `"Number"`;
+
+exports[`
+x = 1
+get(t(1,2), x)
+ 1`] = `"Type check error: Tuple index must be a literal number. Instead it was Identifier."`;
+
+exports[`
 x => {
   x = 3
   x
@@ -132,6 +142,16 @@ exports[`f => g => arg => (g (f arg)) 1`] = `"(D -> E) -> (E -> F) -> D -> F"`;
 exports[`fibonacci.peach 1`] = `"Array<Number>"`;
 
 exports[`function.peach 1`] = `"A -> A"`;
+
+exports[`get([1,2], 0) 1`] = `"Number"`;
+
+exports[`get([1,2], 3) 1`] = `"Number"`;
+
+exports[`get(t(1,\`2\`), 1) 1`] = `"String"`;
+
+exports[`get(t(1,2), 0) 1`] = `"Number"`;
+
+exports[`get(t(1,2), 2) 1`] = `"Type check error: Tuple index out of bounds for (Number, Number)."`;
 
 exports[`if (1) 1 else 2 1`] = `"Type error: type mismatch"`;
 

--- a/src/__tests__/lang-tests.ts
+++ b/src/__tests__/lang-tests.ts
@@ -274,3 +274,9 @@ f = a => {
 }
 [[a], (f 2)]
 `, [[1], [2, 5]])
+
+
+// Tuples
+testResult(`t(1, 2)`, [1, 2])
+testResult(`t()`, [])
+testResult('t(t(), t(`hi`, 1))', [[], [`hi`, 1]])

--- a/src/__tests__/lang-tests.ts
+++ b/src/__tests__/lang-tests.ts
@@ -280,3 +280,8 @@ f = a => {
 testResult(`t(1, 2)`, [1, 2])
 testResult(`t()`, [])
 testResult('t(t(), t(`hi`, 1))', [[], [`hi`, 1]])
+
+// Member access
+testResult('get(t(`a`, `b`), 1)', `b`)
+testResult(`get([1,2,3], 0)`, 1)
+testResult(`get([1,2,3], 3)`, undefined)

--- a/src/__tests__/parser-tests.ts
+++ b/src/__tests__/parser-tests.ts
@@ -14,7 +14,7 @@ function testFixture (fixtureName: string) {
 
 function testParse (source: string) {
   test(source, () => {
-    console.log(JSON.stringify(parse(source)))
+    // console.log(JSON.stringify(parse(source)))
     expect(parse(source)).toMatchSnapshot()
   })
 }
@@ -33,3 +33,7 @@ testParse(`[1,2,3]`)
 testParse(`(test)`)
 testParse(`(test 1)`)
 testParse(`(test 1, 2)`)
+
+testParse(`t()`)
+testParse(`t(1, 2)`)
+testParse(`t(\`1\`, (2), (x) => 3)`)

--- a/src/__tests__/parser-tests.ts
+++ b/src/__tests__/parser-tests.ts
@@ -37,3 +37,5 @@ testParse(`(test 1, 2)`)
 testParse(`t()`)
 testParse(`t(1, 2)`)
 testParse(`t(\`1\`, (2), (x) => 3)`)
+
+testParse('get(t(`a`), 0)')

--- a/src/__tests__/type-checker-tests.ts
+++ b/src/__tests__/type-checker-tests.ts
@@ -12,7 +12,8 @@ import {
   TypeOperator,
   FunctionType,
   NumberType,
-  BooleanType
+  BooleanType,
+  TupleType
 } from '../types'
 
 function testTypeCheck (source: string, env = getTypeEnv(getRootEnv())) {
@@ -254,3 +255,8 @@ x => {
   x = 3
   x
 }`)
+
+// tuples
+testTypeCheck(`t(1, 2)`)
+testTypeCheck(`t()`)
+testTypeCheck('t(t(), t(`hi`, 1, x => t(x, (+ x, 1))))')

--- a/src/__tests__/type-checker-tests.ts
+++ b/src/__tests__/type-checker-tests.ts
@@ -260,3 +260,25 @@ x => {
 testTypeCheck(`t(1, 2)`)
 testTypeCheck(`t()`)
 testTypeCheck('t(t(), t(`hi`, 1, x => t(x, (+ x, 1))))')
+
+// member access
+
+// any index of an array may be fetched. All elements have the same type,
+// and there is no bounds check
+testTypeCheck(`get([1,2], 0)`)
+testTypeCheck(`get([1,2], 3)`) // TODO Maybe type for array access
+testTypeCheck(`
+x = 1
+get([1,2], x)
+`)
+
+// tuples have a static number of elements. Only indexoes in that range
+// may be fetched. The index must be a Number literal so we can guarantee
+// that the element exists.
+testTypeCheck(`get(t(1,2), 0)`)
+testTypeCheck('get(t(1,`2`), 1)')
+testFails(`get(t(1,2), 2)`)
+testFails(`
+x = 1
+get(t(1,2), x)
+`)

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -6,7 +6,7 @@ import { getRootEnv, RuntimeEnv } from './env'
 import {
   Value, TypedAst, TypedNode, TypedProgramNode, TypedDefNode, TypedIdentifierNode,
   TypedNumberNode, TypedBooleanNode, TypedStringNode, TypedCallNode, TypedArrayNode,
-  TypedDestructuredArrayNode, TypedFunctionNode, TypedIfNode, TypedTupleNode
+  TypedDestructuredArrayNode, TypedFunctionNode, TypedIfNode, TypedTupleNode, TypedMemberNode
 } from './node-types'
 
 export type InterpreterResult = [Value, RuntimeEnv]
@@ -58,6 +58,8 @@ function visit (node: TypedNode, env: RuntimeEnv): InterpreterResult {
       return visitIf(node, env)
     case 'Tuple':
       return visitTuple(node, env)
+    case 'Member':
+      return visitMember(node, env)
     default:
       throw new Error(`Uncrecognised AST node kind: ${node.kind}`)
   }
@@ -130,4 +132,14 @@ function visitIf ({ condition, ifBranch, elseBranch }: TypedIfNode, env: Runtime
 function visitTuple({ values }: TypedTupleNode, env: RuntimeEnv): InterpreterResult {
   const results = values.map((value) => visit(value, env)[0])
   return [results, env]
+}
+
+function visitMember({ source, name }: TypedMemberNode, env: RuntimeEnv): InterpreterResult {
+  const [sourceValue] = visit(source, env);
+  const [index] = visit(name, env);
+
+  // TODO runtime types for Array and Type
+  const result = sourceValue[index as number]
+
+  return [result, env]
 }

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -6,7 +6,7 @@ import { getRootEnv, RuntimeEnv } from './env'
 import {
   Value, TypedAst, TypedNode, TypedProgramNode, TypedDefNode, TypedIdentifierNode,
   TypedNumberNode, TypedBooleanNode, TypedStringNode, TypedCallNode, TypedArrayNode,
-  TypedDestructuredArrayNode, TypedFunctionNode, TypedIfNode
+  TypedDestructuredArrayNode, TypedFunctionNode, TypedIfNode, TypedTupleNode
 } from './node-types'
 
 export type InterpreterResult = [Value, RuntimeEnv]
@@ -56,6 +56,8 @@ function visit (node: TypedNode, env: RuntimeEnv): InterpreterResult {
       return visitFn(node, env)
     case 'If':
       return visitIf(node, env)
+    case 'Tuple':
+      return visitTuple(node, env)
     default:
       throw new Error(`Uncrecognised AST node kind: ${node.kind}`)
   }
@@ -123,4 +125,9 @@ function visitIf ({ condition, ifBranch, elseBranch }: TypedIfNode, env: Runtime
   const branch = (testResult) ? ifBranch : elseBranch
 
   return visit(branch, env)
+}
+
+function visitTuple({ values }: TypedTupleNode, env: RuntimeEnv): InterpreterResult {
+  const results = values.map((value) => visit(value, env)[0])
+  return [results, env]
 }

--- a/src/node-types.ts
+++ b/src/node-types.ts
@@ -26,6 +26,7 @@ export type AstNode
   | AstFunctionClauseNode
   | AstIfNode
   | AstTupleNode
+  | AstMemberNode
   | AstDefPreValueNode
 
 // Typed*: type checker output. AST nodes augmented with Peach static types.
@@ -43,6 +44,7 @@ export type TypedNode
   | TypedFunctionClauseNode
   | TypedIfNode
   | TypedTupleNode
+  | TypedMemberNode
   | TypedDefPreValueNode
 
 export interface Typed {
@@ -167,6 +169,17 @@ export interface AstTupleNode {
 
 export interface TypedTupleNode extends AstTupleNode, Typed {
   values: TypedNode[]
+}
+
+export interface AstMemberNode {
+  kind: 'Member',
+  source: AstNode,
+  name: AstNode
+}
+
+export interface TypedMemberNode extends AstMemberNode, Typed {
+  source: TypedNode,
+  name: TypedNode
 }
 
 //

--- a/src/node-types.ts
+++ b/src/node-types.ts
@@ -25,6 +25,7 @@ export type AstNode
   | AstFunctionNode
   | AstFunctionClauseNode
   | AstIfNode
+  | AstTupleNode
   | AstDefPreValueNode
 
 // Typed*: type checker output. AST nodes augmented with Peach static types.
@@ -41,6 +42,7 @@ export type TypedNode
   | TypedFunctionNode
   | TypedFunctionClauseNode
   | TypedIfNode
+  | TypedTupleNode
   | TypedDefPreValueNode
 
 export interface Typed {
@@ -156,6 +158,15 @@ export interface TypedIfNode extends AstIfNode, Typed {
   condition: TypedNode,
   ifBranch: TypedNode,
   elseBranch: TypedNode
+}
+
+export interface AstTupleNode {
+  kind: 'Tuple',
+  values: AstNode[]
+}
+
+export interface TypedTupleNode extends AstTupleNode, Typed {
+  values: TypedNode[]
 }
 
 //

--- a/src/peach.pegjs
+++ b/src/peach.pegjs
@@ -18,6 +18,7 @@ expression
   / string
   / array
   / tuple
+  / member
   / call
   / identifier
 
@@ -181,12 +182,22 @@ non_empty_array = ls values:value_list rs {
   }
 }
 
-// temp syntax
+// temp syntax until I figure out how I want syntax to look and feel on the whole
 tuple = "t" lp items:value_list? rp {
   const values = items || []
   return {
     kind: "Tuple",
     values
+  }
+}
+
+// access array / tuple member
+// temp syntax until we have left-recursive expressions
+member = "get" _ lp source:expression list_delim name:expression rp {
+  return {
+    kind: "Member",
+    source,
+    name
   }
 }
 

--- a/src/peach.pegjs
+++ b/src/peach.pegjs
@@ -17,6 +17,7 @@ expression
   / boolean
   / string
   / array
+  / tuple
   / call
   / identifier
 
@@ -27,7 +28,7 @@ expression_list =
 }
 
 value_list =
-  head:expression tail:("," _ e:expression { return e })* {
+  head:expression tail:(list_delim e:expression { return e })* {
   return [head, ...tail];
 }
 
@@ -180,6 +181,15 @@ non_empty_array = ls values:value_list rs {
   }
 }
 
+// temp syntax
+tuple = "t" lp items:value_list? rp {
+  const values = items || []
+  return {
+    kind: "Tuple",
+    values
+  }
+}
+
 lp = "(" _ { return "(" }
 rp = _ ")" { return ")" }
 
@@ -207,4 +217,4 @@ eol = [\r\n]+ ignored*
 comment = comment_leader [^\r\n]*
 comment_leader = "#"
 
-list_delim = "," _
+list_delim = _ ',' _

--- a/src/type-checker.ts
+++ b/src/type-checker.ts
@@ -5,10 +5,11 @@ import { TypeEnv } from './env'
 import {
   Ast, AstNode, AstProgramNode, AstDefNode, AstIdentifierNode,
   AstNumberNode, AstBooleanNode, AstStringNode, AstCallNode, AstArrayNode,
-  AstDestructuredArrayNode, AstFunctionNode, AstIfNode,
+  AstDestructuredArrayNode, AstFunctionNode, AstIfNode, AstTupleNode,
   TypedAst, TypedNode, TypedProgramNode, TypedDefNode, TypedIdentifierNode,
   TypedNumberNode, TypedBooleanNode, TypedStringNode, TypedCallNode, TypedArrayNode,
   TypedDestructuredArrayNode, TypedFunctionNode, TypedFunctionClauseNode, TypedIfNode,
+  TypedTupleNode,
   TypedDefPreValueNode
 } from './node-types'
 
@@ -20,6 +21,7 @@ import {
   NumberType,
   StringType,
   BooleanType,
+  TupleType,
   makeFunctionType
 } from './types'
 
@@ -72,6 +74,8 @@ function visit (node: AstNode, env: TypeEnv, nonGeneric: Set<Type>): TypeCheckRe
       return visitFn(node, env, nonGeneric)
     case 'If':
       return visitIf(node, env, nonGeneric)
+    case 'Tuple':
+      return visitTuple(node, env, nonGeneric)
     default:
       throw new Error(`Uncrecognised AST node type: ${node.kind}`)
   }
@@ -259,6 +263,14 @@ function visitIf (node: AstIfNode, env: TypeEnv, nonGeneric: Set<Type>): TypeChe
   unify(typeOf(ifBranch), typeOf(elseBranch))
 
   const typedNode = { ...node, condition, ifBranch, elseBranch, type: typeOf(ifBranch) }
+  return [typedNode, env]
+}
+
+function visitTuple (node: AstTupleNode, env: TypeEnv, nonGeneric: Set<Type>): TypeCheckResult<TypedNode> {
+  const values = node.values.map(value => visit(value, env, nonGeneric)[0])
+  const type = new TupleType(typesOf(values))
+
+  const typedNode = { ...node, values, type }
   return [typedNode, env]
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,24 @@ export class ArrayType extends TypeOperator {
   }
 }
 
+export class TupleType extends TypeOperator {
+  constructor (types: Type[]) {
+    super('Tuple', types)
+  }
+
+  static of (name: string, types: Type[]) {
+    return new TupleType(types)
+  }
+
+  getType () {
+    return this.typeArgs[0]
+  }
+
+  toString () {
+    return `(${this.typeArgs.join(', ')})`
+  }
+}
+
 export class TypeVariable extends Type {
   static nextId: number
   static nextName: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,12 +95,16 @@ export class TupleType extends TypeOperator {
     return new TupleType(types)
   }
 
-  getType () {
-    return this.typeArgs[0]
+  getTypeAt (i: number) {
+    return this.typeArgs[i]
   }
 
   toString () {
     return `(${this.typeArgs.join(', ')})`
+  }
+
+  getLength() {
+    return this.typeArgs.length
   }
 }
 


### PR DESCRIPTION
First cut of a Tuple type with some temporary features:

* Temporary tuple expression `t(<...members>)`
* Tuple is represented by a JavaScript array at runtime
* Temporary `get(source, index)` expression (to be replaced by a left-recursive version like `source[index]`. Works for Arrays and Tuples. `index` must be a number literal for tuples.

Syntax is temporary because I have a lot of choices to make about
function, infix operator and data structure syntax. I want to build some
language features first so I can run "real" programs and decide how I
want the syntax to look and feel.